### PR TITLE
Fixed conv spatial bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can downloaded the fftw3 source code from https://github.com/FFTW/fftw3.git
 
 and the clFFT from https://github.com/listenlink/clFFT.git
 
-Then config the Cmake option with ```-DUSE_FFT=ON``` when useing cmake build system or enable the Makefile.config.example line 36 ```USE_FFT := 1``` when using makefile build system
+Then config the Cmake option with ```-DUSE_FFT=ON``` when using cmake build system or enable the Makefile.config.example line 36 ```USE_FFT := 1``` when using makefile build system
 
 Like the ```INTEL_SPATIAL```, modify the convolution_param to ```engine: FFT```to use fft based convolution engine.
 

--- a/examples/mnist/convert_mnist_data.cpp
+++ b/examples/mnist/convert_mnist_data.cpp
@@ -22,8 +22,8 @@
 #include <fstream>  // NOLINT(readability/streams)
 #include <string>
 
-#include "caffe/definitions.hpp"
 #include "boost/scoped_ptr.hpp"
+#include "caffe/definitions.hpp"
 #include "caffe/proto/caffe.pb.h"
 #include "caffe/util/db.hpp"
 #include "caffe/util/format.hpp"

--- a/include/caffe/layers/conv_spatial_layer.hpp
+++ b/include/caffe/layers/conv_spatial_layer.hpp
@@ -68,22 +68,17 @@ class ConvolutionLayerSpatial : public BaseConvolutionLayer<Dtype> {
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
                            const vector<Blob<Dtype>*>& top);
-#ifndef CPU_ONLY
-#ifdef USE_GREENTEA
+
   virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
                            const vector<Blob<Dtype>*>& top);
-#endif
-#endif
+
   virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
                             const vector<bool>& propagate_down,
                             const vector<Blob<Dtype>*>& bottom);
-#ifndef CPU_ONLY
-#ifdef USE_GREENTEA
+
   virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
                             const vector<bool>& propagate_down,
                             const vector<Blob<Dtype>*>& bottom);
-#endif
-#endif
 
   virtual inline bool reverse_dimensions() {
     return false;

--- a/src/caffe/layers/conv_layer_spatial.cu
+++ b/src/caffe/layers/conv_layer_spatial.cu
@@ -16,17 +16,15 @@
 #endif
 
 namespace caffe {
-
+#ifndef CPU_ONLY
 #ifdef USE_GREENTEA
 
 // #define dbg
-
 #ifdef dbg
 #define dbgPrint(x) (x)
 #else
 #define dbgPrint(x)
 #endif
-
 
 template<>
 void ConvolutionLayerSpatial<float>::generate_key() {
@@ -1357,7 +1355,20 @@ void ConvolutionLayerSpatial<double>::Backward_gpu(
     const vector<Blob<double>*>& bottom) {
   NOT_IMPLEMENTED;
 }
+#else
+template<typename Dtype>
+void ConvolutionLayerSpatial<Dtype>::Forward_gpu(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  NOT_IMPLEMENTED;
+}
 
+template<typename Dtype>
+void ConvolutionLayerSpatial<Dtype>::Backward_gpu(
+    const vector<Blob<Dtype>*>& top, const vector<bool>& propagate_down,
+    const vector<Blob<Dtype>*>& bottom) {
+  NOT_IMPLEMENTED;
+}
+#endif
 INSTANTIATE_LAYER_GPU_FUNCS(ConvolutionLayerSpatial);
 #endif
 

--- a/src/caffe/layers/conv_layer_spatial.cu
+++ b/src/caffe/layers/conv_layer_spatial.cu
@@ -1141,7 +1141,7 @@ void ConvolutionLayerSpatial<float>::Backward_gpu(
 
 template<typename Dtype>
 void ConvolutionLayerSpatial<Dtype>::load_cached_kernels(
-   const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
   // Generates static key_
   if (tuned_)
     return;
@@ -1165,15 +1165,15 @@ void ConvolutionLayerSpatial<Dtype>::load_cached_kernels(
     cachedKernel >> type;
     create_convolution_kernel(bottom, top, type, x, y, z);
     kernel_index_ = kernelQueue.size() - 1;
-    if (kernel_index_ == -1) {
-      std::cerr << "Failed to get kernel from cached configurations."
-                << std::endl;
-      std::cerr << "Deleting broken cache file and try tuning again..."
-                << std::endl;
-      string bakFile = outputFile + ".bak";
-      std::rename(outputFile.c_str(), bakFile.c_str());
-      return;
-    }
+  if (kernel_index_ == -1) {
+    std::cerr << "Failed to get kernel from cached configurations."
+              << std::endl;
+    std::cerr << "Deleting broken cache file and try tuning again..."
+              << std::endl;
+    string bakFile = outputFile + ".bak";
+    std::rename(outputFile.c_str(), bakFile.c_str());
+    return;
+  }
     cachedKernel >> kernelQueue[kernel_index_]->global_work_size[0];
     cachedKernel >> kernelQueue[kernel_index_]->global_work_size[1];
     cachedKernel >> kernelQueue[kernel_index_]->global_work_size[2];
@@ -1185,13 +1185,14 @@ void ConvolutionLayerSpatial<Dtype>::load_cached_kernels(
     cachedKernel >> kernelQueue[kernel_index_]->use_null_local;
 
     tuned_ = true;
-   }
-   return;
+  }
+  return;
 }
 
 template<typename Dtype>
 void ConvolutionLayerSpatial<Dtype>::SetUp(
-    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top, caffe::Backend backend) {
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top,
+    caffe::Backend backend) {
   if (backend == caffe::BACKEND_OpenCL) {
     load_cached_kernels(bottom, top);
   }

--- a/src/caffe/syncedmem.cpp
+++ b/src/caffe/syncedmem.cpp
@@ -132,9 +132,9 @@ inline void SyncedMemory::to_cpu() {
 #ifdef USE_GREENTEA
         viennacl::ocl::context &ctx = viennacl::ocl::get_context(
             device_->id());
-        if (!own_zero_copy_data_)
+        if (!own_zero_copy_data_) {
           greentea_gpu_memcpy(size_, (cl_mem) gpu_ptr_, 0, cpu_ptr_, &ctx);
-        else {
+        } else {
           void *mapped_ptr = clEnqueueMapBuffer(ctx.get_queue().handle().get(),
                                 (cl_mem) gpu_ptr_,
                                 true,
@@ -184,16 +184,17 @@ inline void SyncedMemory::to_gpu() {
                      CL_MEM_READ_WRITE | CL_MEM_ALLOC_HOST_PTR,
                      size_, nullptr, &err);
         } else if (device_->isHostUnified()) {
-            //auto saved_mode = Caffe::mode();
-            //Caffe::set_mode(Caffe::GPU);
+            // auto saved_mode = Caffe::mode();
+            // Caffe::set_mode(Caffe::GPU);
             CaffeMallocHost(&cpu_ptr_, size_, device_);
-            //Caffe::set_mode(saved_mode);
+            // Caffe::set_mode(saved_mode);
             caffe_memset(size_, 0, cpu_ptr_);
             own_cpu_data_ = true;
             cl_gpu_mem_ = clCreateBuffer(ctx.handle().get(),
                               CL_MEM_READ_WRITE | CL_MEM_USE_HOST_PTR,
                               size_, cpu_ptr_, &err);
-            void *mapped_ptr = clEnqueueMapBuffer(ctx.get_queue().handle().get(),
+            void *mapped_ptr = clEnqueueMapBuffer(
+                                  ctx.get_queue().handle().get(),
                                   cl_gpu_mem_,
                                   true,
                                   CL_MAP_READ | CL_MAP_WRITE,
@@ -249,11 +250,12 @@ inline void SyncedMemory::to_gpu() {
             cl_gpu_mem_ = clCreateBuffer(
                 ctx.handle().get(), CL_MEM_READ_WRITE | CL_MEM_ALLOC_HOST_PTR,
                 size_, nullptr, &err);
-          } else if(ZEROCOPY_SUPPORTED(device_, cpu_ptr_, size_)) {
+          } else if (ZEROCOPY_SUPPORTED(device_, cpu_ptr_, size_)) {
               cl_gpu_mem_ = clCreateBuffer(ctx.handle().get(),
                                CL_MEM_READ_WRITE | CL_MEM_USE_HOST_PTR,
                                size_, cpu_ptr_, &err);
-              void *mapped_ptr = clEnqueueMapBuffer(ctx.get_queue().handle().get(),
+              void *mapped_ptr = clEnqueueMapBuffer(
+                                    ctx.get_queue().handle().get(),
                                     (cl_mem) cl_gpu_mem_,
                                     true,
                                     CL_MAP_READ | CL_MAP_WRITE,


### PR DESCRIPTION
1.Fixed bug when using the cpu version of conv spatial
2.Fixed building with CPU_ONLY/USE_CUDA/USE_GREENTEA now enable the situations:
```
-DCPU_ONLY=ON
-DUSE_CUDA=OFF -DUSE_GREENTEA=ON
-DUSE_CUDA=ON -DUSE_GREENTEA=ON
-DUSE_CUDA=ON -DUSE_GREENTEA=OFF
```