### PR TITLE
 Eabled Hybrid convolution spatial and fixed Building warning of CMAKE 

### DIFF
--- a/cmake/Modules/FindMKL.cmake
+++ b/cmake/Modules/FindMKL.cmake
@@ -14,7 +14,7 @@
 
 
 # ---[ Options
-caffe_option(MKL_USE_SINGLE_DYNAMIC_LIBRARY "Use single dynamic library interface" ON)
+caffe_option(MKL_USE_SINGLE_DYNAMIC_LIBRARY "Use single dynamic library interface" OFF)
 caffe_option(MKL_USE_STATIC_LIBS "Use static libraries" OFF IF NOT MKL_USE_SINGLE_DYNAMIC_LIBRARY)
 caffe_option(MKL_MULTI_THREADED  "Use multi-threading"   ON IF NOT MKL_USE_SINGLE_DYNAMIC_LIBRARY)
 

--- a/include/caffe/layers/conv_spatial_layer.hpp
+++ b/include/caffe/layers/conv_spatial_layer.hpp
@@ -11,7 +11,6 @@
 #include "caffe/layers/base_conv_layer.hpp"
 
 namespace caffe {
-
 template<typename Dtype>
 class ConvolutionLayerSpatial : public BaseConvolutionLayer<Dtype> {
  public:
@@ -91,6 +90,7 @@ class ConvolutionLayerSpatial : public BaseConvolutionLayer<Dtype> {
     size_t local_work_size[3];
     size_t global_work_size[3];
     int_tp workItem_output[3];
+    int_tp cpu_work_size;
     bool verified;
     bool autoTune;
     bool tested;
@@ -102,7 +102,7 @@ class ConvolutionLayerSpatial : public BaseConvolutionLayer<Dtype> {
     kernelConfig() {
     }
     kernelConfig(string name, size_t* global_size, size_t* local_size,
-    int_tp* workItem,
+    int_tp* workItem, int_tp cpu_size,
                  bool tune, bool swizzle, bool batched, bool null_local,
                  int_tp type = 0) {
       kernelName = name;
@@ -111,6 +111,7 @@ class ConvolutionLayerSpatial : public BaseConvolutionLayer<Dtype> {
         global_work_size[x] = global_size[x];
         workItem_output[x] = workItem[x];
       }
+      cpu_work_size = cpu_size;
       autoTune = tune;
       swizzle_weights = swizzle;
       batched_execute = batched;
@@ -161,6 +162,10 @@ class ConvolutionLayerSpatial : public BaseConvolutionLayer<Dtype> {
                                   const vector<Blob<Dtype>*>& top, int_tp index,
                                   int_tp numImages,
                                   kernelConfig* config);
+  virtual cl_int convolve_hybrid(const vector<Blob<float>*>& bottom,
+                                 const vector<Blob<float>*>& top,
+                                 int_tp index,
+                                 int_tp numImages, kernelConfig* config);
   virtual float timed_convolve(const vector<Blob<Dtype>*>& bottom,
                                const vector<Blob<Dtype>*>& top, int_tp index,
                                int_tp numImages,
@@ -177,9 +182,10 @@ class ConvolutionLayerSpatial : public BaseConvolutionLayer<Dtype> {
   virtual void generate_key();
   virtual std::string generate_unique_key();
   virtual std::string generate_specific_key(int_tp type, int_tp blockWidth,
-  int_tp blockHeight,
+                                            int_tp blockHeight,
                                             int_tp blockDepth);
-  virtual void calculate_global_size(int_tp batch, int_tp* workItemOutput,
+  virtual void calculate_global_size(int_tp batch, int_tp output_channels,
+                                     int_tp* workItemOutput,
                                      size_t* localSizes, size_t* globalSizes);
   void load_cached_kernels(const vector<Blob<Dtype>*>& bottom,
                            const vector<Blob<Dtype>*>& top);
@@ -187,7 +193,6 @@ class ConvolutionLayerSpatial : public BaseConvolutionLayer<Dtype> {
              const vector<Blob<Dtype>*>& top, caffe::Backend backend);
 #endif
 #endif
-
   const Dtype* bottom_data;
   Dtype* top_data;
   Dtype* col_data;
@@ -210,7 +215,6 @@ class ConvolutionLayerSpatial : public BaseConvolutionLayer<Dtype> {
   int_tp pad_w_;
   int_tp stride_h_;
   int_tp stride_w_;
-
   /// M_ is the channel dimension of the output for a single group, which is the
   /// leading dimension of the filter matrix.
   int_tp M_;

--- a/src/caffe/layers/conv_layer_spatial.cu
+++ b/src/caffe/layers/conv_layer_spatial.cu
@@ -1180,6 +1180,7 @@ void ConvolutionLayerSpatial<float>::setup_convolution(
             && kernelQueue[x]->tested == false) {
           fastestKernel = x;
           fastestTime = kernelQueue[x]->executionTime;
+          std::cout<<"fastest time is : " << fastestTime <<" kernel index is: " << x << std::endl;
         }
       }
       if (fastestKernel < 0) break;
@@ -1202,7 +1203,7 @@ void ConvolutionLayerSpatial<float>::setup_convolution(
   }
   if (verification) {
     dbgPrint(std::cout << "Kernel <" << kernelQueue[kernel_index_]->kernelName
-                       << "> passed verification" << std::endl);
+                       << "> passed verification" << " kernel index: " << kernel_index_ << std::endl);
   } else {
     dbgPrint(std::cout << "Verification was not successful, "
                        << "fallback to basic kernel" << std::endl);

--- a/src/caffe/layers/conv_layer_spatial.cu
+++ b/src/caffe/layers/conv_layer_spatial.cu
@@ -820,6 +820,9 @@ float ConvolutionLayerSpatial<float>::timed_convolve(
   double k_h = kernel_h_;
   double k_z = channels_;
   double totalFlops = ((k_w*k_h*k_z -1)*2)*(out_w*out_h*out_z)*num_;
+  if (err != CL_SUCCESS) {
+    std::cout<< "failed on timed_convolve" << std::endl;
+  }
   std::cout << "Kernel: " << config->kernelName << std::endl;
   std::cout << "\tEstimated Gflops:" << ((totalFlops/1000)/1000)/1000
             << std::endl;
@@ -1144,10 +1147,12 @@ void ConvolutionLayerSpatial<float>::setup_convolution(
   }
   for (int_tp y = 1; y < 4; y += 1)
     for (int_tp z = 1; z < 16 && z < M_; z += 1) {
+      /*
       if (4 * y * z > 32) continue;
       create_convolution_kernel(bottom, top, 1, 4, y, z);
       if (num_ > 1)
         create_convolution_kernel(bottom, top, 3, 4, y, z);
+      */
     }
   for (int_tp x = 0; x < kernelQueue.size(); x++)
     if (tune_local_size(bottom, top, kernelQueue[x])) {

--- a/src/caffe/layers/conv_layer_spatial.cu
+++ b/src/caffe/layers/conv_layer_spatial.cu
@@ -807,6 +807,7 @@ float ConvolutionLayerSpatial<float>::timed_convolve(
 #endif
   timer.Stop();
   if (err != CL_SUCCESS) {
+    std::cout<< "failed on timed_convolve" << std::endl;
     config->tested = true;
     config->verified = false;
   }

--- a/src/caffe/layers/conv_layer_spatial.cu
+++ b/src/caffe/layers/conv_layer_spatial.cu
@@ -1136,24 +1136,24 @@ void ConvolutionLayerSpatial<float>::setup_convolution(
     M_ % 16 == 0) {
     /* IDLF kernel is using Intel specific extension which make
        them intel only. */
-    create_convolution_kernel(bottom, top, 2, 4, 2, 1);
-    create_convolution_kernel(bottom, top, 2, 4, 4, 1);
-    create_convolution_kernel(bottom, top, 2, 8, 2, 1);
-    create_convolution_kernel(bottom, top, 2, 8, 4, 1);
-    create_convolution_kernel(bottom, top, 2, 6, 4, 1);
-    create_convolution_kernel(bottom, top, 2, 3, 3, 1);
-    create_convolution_kernel(bottom, top, 2, 5, 5, 1);
-    create_convolution_kernel(bottom, top, 2, 3, 4, 1);
-    create_convolution_kernel(bottom, top, 2, 6, 4, 1);
+    if (this->blobs()[0]->shape()[2] > 5) {
+      create_convolution_kernel(bottom, top, 2, 4, 2, 1);
+      create_convolution_kernel(bottom, top, 2, 4, 4, 1);
+      create_convolution_kernel(bottom, top, 2, 8, 2, 1);
+      create_convolution_kernel(bottom, top, 2, 8, 4, 1);
+      create_convolution_kernel(bottom, top, 2, 6, 4, 1);
+      create_convolution_kernel(bottom, top, 2, 3, 3, 1);
+      create_convolution_kernel(bottom, top, 2, 5, 5, 1);
+      create_convolution_kernel(bottom, top, 2, 3, 4, 1);
+      create_convolution_kernel(bottom, top, 2, 6, 4, 1);
+    }
   }
   for (int_tp y = 1; y < 4; y += 1)
     for (int_tp z = 1; z < 16 && z < M_; z += 1) {
-      /*
       if (4 * y * z > 32) continue;
       create_convolution_kernel(bottom, top, 1, 4, y, z);
       if (num_ > 1)
         create_convolution_kernel(bottom, top, 3, 4, y, z);
-      */
     }
   for (int_tp x = 0; x < kernelQueue.size(); x++)
     if (tune_local_size(bottom, top, kernelQueue[x])) {


### PR DESCRIPTION
remove the redefined of 
```
#cmakedefine USE_OPENCV
#cmakedefine USE_LEVELDB
#cmakedefine USE_LMDB
#cmakedefine ALLOW_LMDB_NOLOCK
```
and other unused variables