### PR TITLE
Enable CLBlast library on CMAKE build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ caffe_option(USE_CUDA "Build Caffe with CUDA support" ON)
 caffe_option(USE_GREENTEA "Build Caffe with OpenCL support" ON)
 caffe_option(USE_LIBDNN "Build Caffe with OpenCL libdnn" OFF)
 caffe_option(USE_CLBLAS "Build Caffe with clBLAS support (instead of using ViennaClBLAS)" OFF)
+caffe_option(USE_CLBLAST "Build Caffe with CLBlast support (instead of using ViennaClBLAS)" OFF)
 caffe_option(USE_ISAAC "Build Caffe with ISAAC support (instead of using ViennaClBLAS)" OFF)
 caffe_option(USE_CUDNN "Build Caffe with cuDNN libary support" OFF)
 caffe_option(BUILD_SHARED_LIBS "Build shared libraries" ON)
@@ -56,6 +57,10 @@ endif()
 
 if(USE_ISAAC)
   set(USE_CLBLAS ON)
+endif()
+
+if(USE_CLBLAST)
+  set(USE_CLBLAS OFF)
 endif()
 
 # ---[ Dependencies

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -136,6 +136,18 @@ if (USE_ISAAC)
   set(HAVE_ISAAC TRUE)
 endif()
 
+
+# ---[ CLBLAST
+if (USE_CLBLAST)
+  find_package(CLBlast)
+  if (NOT CLBLAST_FOUND)
+    message(FATAL_ERROR "CLBlast required but not found.")
+  endif()
+  # include_directories(SYSTEM ${CLBLAS_INCLUDE_DIR})
+  list(APPEND Caffe_LINKER_LIBS ${CLBLAST_LIBRARY})
+  set(HAVE_CLBLAST TRUE)
+endif()
+
 # ---[ OpenCV
 if(USE_OPENCV)
   find_package(OpenCV QUIET COMPONENTS core highgui imgproc imgcodecs)

--- a/cmake/Modules/FindCLBlast.cmake
+++ b/cmake/Modules/FindCLBlast.cmake
@@ -1,0 +1,47 @@
+SET(CLBLAST_INCLUDE_SEARCH_PATHS
+  /usr/include
+  /usr/local/include
+  /opt/clblast/include
+  $ENV{CLBLAST_HOME}
+  $ENV{CLBLAST_HOME}/include
+)
+
+SET(CLBLAST_LIB_SEARCH_PATHS
+        /lib
+        /lib64
+        /usr/lib
+        /usr/lib64
+        /usr/local/lib
+        /usr/local/lib64
+        /opt/clblast/lib
+        $ENV{CLBLAST_HOME}
+        $ENV{CLBLAST_HOME}/lib
+ )
+
+FIND_PATH(CLBLAST_INCLUDE_DIR NAMES clblast.h PATHS ${CLBLAST_INCLUDE_SEARCH_PATHS})
+FIND_LIBRARY(CLBLAST_LIBRARY NAMES clblast PATHS ${CLBLAST_LIB_SEARCH_PATHS})
+
+SET(CLBLAST_FOUND ON)
+
+#    Check libraries
+IF(NOT CLBLAST_LIBRARY)
+    SET(CLBLAST_FOUND OFF)
+    MESSAGE(STATUS "Could not find CLBlast lib. Turning CLBLAST_FOUND off")
+ENDIF()
+
+IF (CLBLAST_FOUND)
+  IF (NOT CLBLAST_FIND_QUIETLY)
+    MESSAGE(STATUS "Found CLBLAST libraries: ${CLBLAST_LIBRARY}")
+    MESSAGE(STATUS "Found CLBLAST include: ${CLBLAST_INCLUDE_DIR}")
+  ENDIF (NOT CLBLAST_FIND_QUIETLY)
+ELSE (CLBLAST_FOUND)
+  IF (CLBLAST_FIND_REQUIRED)
+    MESSAGE(FATAL_ERROR "Could not find CLBLAST")
+  ENDIF (CLBLAST_FIND_REQUIRED)
+ENDIF (CLBLAST_FOUND)
+
+MARK_AS_ADVANCED(
+    CLBLAST_INCLUDE_DIR
+    CLBLAST_LIBRARY
+)
+

--- a/cmake/Templates/caffe_config.h.in
+++ b/cmake/Templates/caffe_config.h.in
@@ -24,6 +24,9 @@
 #cmakedefine HAVE_CLBLAS
 #cmakedefine USE_CLBLAS
 
+/* CLBlast */
+#cmakedefine HAVE_CLBLAST
+#cmakedefine USE_CLBLAST
 /* NVIDA cuDNN */
 #cmakedefine HAVE_CUDNN
 #cmakedefine USE_CUDNN


### PR DESCRIPTION
Hi @gongzg ,

This patch added the cmake build support for CLBlast, need add ```cmake -DUSE_CLBLAST=ON``` to enable it