### PR TITLE
OpenCL version of Permute and Normalize layer enabled

### DIFF
--- a/include/caffe/layers/normalize_layer.hpp
+++ b/include/caffe/layers/normalize_layer.hpp
@@ -31,16 +31,12 @@ class NormalizeLayer : public Layer<Dtype> {
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
-#ifdef USE_CUDA
   virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
-#endif // USE_CUDA
   virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
-#ifdef USE_CUDA
   virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
-#endif //USE_CUDA
 
   Blob<Dtype> norm_;
   Blob<Dtype> sum_channel_multiplier_, sum_spatial_multiplier_;

--- a/include/caffe/layers/permute_layer.hpp
+++ b/include/caffe/layers/permute_layer.hpp
@@ -38,17 +38,12 @@ class PermuteLayer : public Layer<Dtype> {
  protected:
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
-#ifdef USE_CUDA
   virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
-#endif
   virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
-#ifdef USE_CUDA
   virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
-#endif
-
   int num_axes_;
   bool need_permute_;
 

--- a/src/caffe/greentea/cl_kernels.cpp
+++ b/src/caffe/greentea/cl_kernels.cpp
@@ -5706,6 +5706,35 @@ static std::vector<std::vector<std::string>> cl_kernels{
 "#include \"header.cl\"",    // NOLINT
 "#endif",    // NOLINT
 "",    // NOLINT
+"#define OCL_KERNEL_LOOP(i, n)  for (int i = get_global_id(0); i < (n); i += get_global_size(0))",    // NOLINT
+"",    // NOLINT
+"__kernel void TEMPLATE(PermuteKernel, Dtype)(const int nthreads,",    // NOLINT
+"__global Dtype* bottom_data, const int forward, global int* permute_order,",    // NOLINT
+"global int* old_steps, global int* new_steps, const int num_axes,",    // NOLINT
+"__global Dtype* top_data) {",    // NOLINT
+"OCL_KERNEL_LOOP(index, nthreads) {",    // NOLINT
+"int temp_idx = index;",    // NOLINT
+"int old_idx = 0;",    // NOLINT
+"for (int i = 0; i < num_axes; ++i) {",    // NOLINT
+"int order = permute_order[i];",    // NOLINT
+"old_idx += (temp_idx / new_steps[i]) * old_steps[order];",    // NOLINT
+"temp_idx %= new_steps[i];",    // NOLINT
+"}",    // NOLINT
+"if (forward != 0) {",    // NOLINT
+"top_data[index] = bottom_data[old_idx];",    // NOLINT
+"} else {",    // NOLINT
+"bottom_data[old_idx] = top_data[index];",    // NOLINT
+"}",    // NOLINT
+"}",    // NOLINT
+"}",    // NOLINT
+"",    // NOLINT
+"",    // NOLINT
+"",    // NOLINT
+""},   // NOLINT
+    {"#ifndef __OPENCL_VERSION__",    // NOLINT
+"#include \"header.cl\"",    // NOLINT
+"#endif",    // NOLINT
+"",    // NOLINT
 "void TEMPLATE(max_pool_forward_impl, Dtype)(",    // NOLINT
 "const int_tp nthreads, __global const Dtype* bottom_data, const int_tp num,",    // NOLINT
 "const int_tp channels, const int_tp height, const int_tp width,",    // NOLINT
@@ -6975,6 +7004,7 @@ static std::string cl_kernel_names[] = {
     "math",   // NOLINT
     "matvec_mul",   // NOLINT
     "mergecrop",   // NOLINT
+    "permute_layer",   // NOLINT
     "pooling",   // NOLINT
     "pooling_nd",   // NOLINT
     "pooling_sk",   // NOLINT

--- a/src/caffe/greentea/cl_kernels.cpp
+++ b/src/caffe/greentea/cl_kernels.cpp
@@ -5706,6 +5706,37 @@ static std::vector<std::vector<std::string>> cl_kernels{
 "#include \"header.cl\"",    // NOLINT
 "#endif",    // NOLINT
 "",    // NOLINT
+"__kernel void TEMPLATE(DivBsx, Dtype)(const int nthreads,",    // NOLINT
+"__global const Dtype* A, const int A_off, __global const Dtype* v, const int v_off, const int rows, const int cols,",    // NOLINT
+"__global Dtype* B, const int B_off) {",    // NOLINT
+"",    // NOLINT
+"for (int index = get_global_id(0); index < nthreads; index += get_global_size(0)) {",    // NOLINT
+"int c = index % cols;",    // NOLINT
+"B[index+B_off] = A[index+A_off] / v[c+v_off];",    // NOLINT
+"}",    // NOLINT
+"}",    // NOLINT
+"",    // NOLINT
+"__kernel void TEMPLATE(MulBsx, Dtype)(const int nthreads, __global Dtype* A, const int A_off,",    // NOLINT
+"__global Dtype* v, const int rows, const int cols, int trans,",    // NOLINT
+"__global Dtype* B, const int B_off) {",    // NOLINT
+"for (int index = get_global_id(0); index < nthreads; index += get_global_size(0)) {",    // NOLINT
+"int c = index % cols;",    // NOLINT
+"int r = (index / cols) % rows;",    // NOLINT
+"if (trans == 0) {",    // NOLINT
+"B[index+B_off] = A[index+A_off] * v[c];",    // NOLINT
+"} else {",    // NOLINT
+"B[index+B_off] = A[index+A_off] * v[r];",    // NOLINT
+"}",    // NOLINT
+"}",    // NOLINT
+"}",    // NOLINT
+"",    // NOLINT
+"",    // NOLINT
+"",    // NOLINT
+""},   // NOLINT
+    {"#ifndef __OPENCL_VERSION__",    // NOLINT
+"#include \"header.cl\"",    // NOLINT
+"#endif",    // NOLINT
+"",    // NOLINT
 "#define OCL_KERNEL_LOOP(i, n)  for (int i = get_global_id(0); i < (n); i += get_global_size(0))",    // NOLINT
 "",    // NOLINT
 "__kernel void TEMPLATE(PermuteKernel, Dtype)(const int nthreads,",    // NOLINT
@@ -7004,6 +7035,7 @@ static std::string cl_kernel_names[] = {
     "math",   // NOLINT
     "matvec_mul",   // NOLINT
     "mergecrop",   // NOLINT
+    "normalize_layer",   // NOLINT
     "permute_layer",   // NOLINT
     "pooling",   // NOLINT
     "pooling_nd",   // NOLINT

--- a/src/caffe/greentea/cl_kernels/normalize_layer.cl
+++ b/src/caffe/greentea/cl_kernels/normalize_layer.cl
@@ -1,0 +1,30 @@
+#ifndef __OPENCL_VERSION__
+#include "header.cl"
+#endif
+ 
+__kernel void TEMPLATE(DivBsx, Dtype)(const int nthreads,
+    __global const Dtype* A, const int A_off, __global const Dtype* v, const int v_off, const int rows, const int cols,
+    __global Dtype* B, const int B_off) {
+
+  for (int index = get_global_id(0); index < nthreads; index += get_global_size(0)) {
+    int c = index % cols;
+    B[index+B_off] = A[index+A_off] / v[c+v_off];
+  }
+}
+
+__kernel void TEMPLATE(MulBsx, Dtype)(const int nthreads, __global Dtype* A, const int A_off,
+    __global Dtype* v, const int rows, const int cols, int trans,
+    __global Dtype* B, const int B_off) {
+  for (int index = get_global_id(0); index < nthreads; index += get_global_size(0)) {
+    int c = index % cols;
+    int r = (index / cols) % rows;
+    if (trans == 0) {
+      B[index+B_off] = A[index+A_off] * v[c];
+    } else {
+      B[index+B_off] = A[index+A_off] * v[r];
+    }
+  }
+}
+
+
+

--- a/src/caffe/greentea/cl_kernels/permute_layer.cl
+++ b/src/caffe/greentea/cl_kernels/permute_layer.cl
@@ -1,0 +1,28 @@
+#ifndef __OPENCL_VERSION__
+#include "header.cl"
+#endif
+
+#define OCL_KERNEL_LOOP(i, n)  for (int i = get_global_id(0); i < (n); i += get_global_size(0))
+ 
+__kernel void TEMPLATE(PermuteKernel, Dtype)(const int nthreads,
+    __global Dtype* bottom_data, const int forward, global int* permute_order,
+    global int* old_steps, global int* new_steps, const int num_axes,
+    __global Dtype* top_data) {
+  OCL_KERNEL_LOOP(index, nthreads) {
+  int temp_idx = index;
+  int old_idx = 0;
+  for (int i = 0; i < num_axes; ++i) {
+    int order = permute_order[i];
+    old_idx += (temp_idx / new_steps[i]) * old_steps[order];
+    temp_idx %= new_steps[i];
+  }
+  if (forward != 0) {
+    top_data[index] = bottom_data[old_idx];
+  } else {
+    bottom_data[old_idx] = top_data[index];
+  }
+}
+}
+
+
+

--- a/src/caffe/layers/normalize_layer.cu
+++ b/src/caffe/layers/normalize_layer.cu
@@ -4,13 +4,13 @@
 
 #ifdef USE_CUDA
 #include "thrust/device_vector.h"
-
+#endif
 #include "caffe/filler.hpp"
 #include "caffe/layers/normalize_layer.hpp"
 #include "caffe/util/math_functions.hpp"
 
 namespace caffe {
-
+#ifdef USE_CUDA
 // divid a matrix with vector
 template <typename Dtype>
 __global__ void DivBsx(const int nthreads, const Dtype* A,
@@ -41,7 +41,7 @@ __global__ void MulBsx(const int nthreads, const Dtype* A,
     }
   }
 }
-
+#endif
 template <typename Dtype>
 void NormalizeLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
@@ -49,66 +49,160 @@ void NormalizeLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
   Dtype* top_data = top[0]->mutable_gpu_data();
   Dtype* buffer_data = buffer_.mutable_gpu_data();
   Dtype* norm_data;
-  if (across_spatial_) {
-    // need to index it
-    norm_data = norm_.mutable_cpu_data();
-  } else {
-    norm_data = norm_.mutable_gpu_data();
-    // add eps to avoid overflow
-    caffe_gpu_set<Dtype>(norm_.count(), Dtype(eps_), norm_data);
-  }
-  const Dtype* scale;
-  if (channel_shared_) {
-    scale = this->blobs_[0]->cpu_data();
-  } else {
-    scale = this->blobs_[0]->gpu_data();
-  }
-  const Dtype* sum_channel_multiplier = sum_channel_multiplier_.gpu_data();
-  int num = bottom[0]->num();
-  int dim = bottom[0]->count() / num;
-  int spatial_dim = bottom[0]->height() * bottom[0]->width();
-  int channels = bottom[0]->channels();
-  for (int n = 0; n < num; ++n) {
-    caffe_gpu_powx<Dtype>(dim, bottom_data, Dtype(2), buffer_data);
+  if (this->device_->backend() == BACKEND_CUDA) {
+#ifdef USE_CUDA
     if (across_spatial_) {
-      Dtype normsqr;
-      caffe_gpu_asum<Dtype>(dim, buffer_data, &normsqr);
+      // need to index it
+      norm_data = norm_.mutable_cpu_data();
+    } else {
+      norm_data = norm_.mutable_gpu_data();
       // add eps to avoid overflow
-      norm_data[n] = pow(normsqr+eps_, Dtype(0.5));
-      caffe_gpu_scale<Dtype>(dim, Dtype(1.0 / norm_data[n]), bottom_data,
-                             top_data);
-    } else {
-      // compute norm
-      caffe_gpu_gemv<Dtype>(CblasTrans, channels, spatial_dim, Dtype(1),
-                            buffer_data, sum_channel_multiplier, Dtype(1),
-                            norm_data);
-      caffe_gpu_powx<Dtype>(spatial_dim, norm_data, Dtype(0.5), norm_data);
-      // scale the layer
-      // NOLINT_NEXT_LINE(whitespace/operators)
-      DivBsx<Dtype> <<<CAFFE_GET_BLOCKS(dim), CAFFE_CUDA_NUM_THREADS>>>(
-          dim, bottom_data, norm_data, channels, spatial_dim, CblasNoTrans,
-          top_data);
-      CUDA_POST_KERNEL_CHECK;
-      norm_data += spatial_dim;
+      caffe_gpu_set<Dtype>(norm_.count(), Dtype(eps_), norm_data);
     }
-    // scale the output
+    const Dtype* scale;
     if (channel_shared_) {
-      caffe_gpu_scal<Dtype>(dim, scale[0], top_data);
+      scale = this->blobs_[0]->cpu_data();
     } else {
-      // NOLINT_NEXT_LINE(whitespace/operators)
-      MulBsx<Dtype> <<<CAFFE_GET_BLOCKS(dim), CAFFE_CUDA_NUM_THREADS>>>(
-          dim, top_data, scale, channels, spatial_dim, CblasTrans,
-          top_data);
-      CUDA_POST_KERNEL_CHECK;
+      scale = this->blobs_[0]->gpu_data();
     }
-    bottom_data += dim;
-    top_data += dim;
+    const Dtype* sum_channel_multiplier = sum_channel_multiplier_.gpu_data();
+    int num = bottom[0]->num();
+    int dim = bottom[0]->count() / num;
+    int spatial_dim = bottom[0]->height() * bottom[0]->width();
+    int channels = bottom[0]->channels();
+    for (int n = 0; n < num; ++n) {
+      caffe_gpu_powx<Dtype>(dim, bottom_data, Dtype(2), buffer_data);
+      if (across_spatial_) {
+        Dtype normsqr;
+        caffe_gpu_asum<Dtype>(dim, buffer_data, &normsqr);
+        // add eps to avoid overflow
+        norm_data[n] = pow(normsqr+eps_, Dtype(0.5));
+        caffe_gpu_scale<Dtype>(dim, Dtype(1.0 / norm_data[n]), bottom_data,
+                               top_data);
+      } else {
+        // compute norm
+        caffe_gpu_gemv<Dtype>(CblasTrans, channels, spatial_dim, Dtype(1),
+                              buffer_data, sum_channel_multiplier, Dtype(1),
+                              norm_data);
+        caffe_gpu_powx<Dtype>(spatial_dim, norm_data, Dtype(0.5), norm_data);
+        // scale the layer
+        // NOLINT_NEXT_LINE(whitespace/operators)
+        DivBsx<Dtype> <<<CAFFE_GET_BLOCKS(dim), CAFFE_CUDA_NUM_THREADS>>>(
+            dim, bottom_data, norm_data, channels, spatial_dim, CblasNoTrans,
+            top_data);
+        CUDA_POST_KERNEL_CHECK;
+        norm_data += spatial_dim;
+      }
+      // scale the output
+      if (channel_shared_) {
+        caffe_gpu_scal<Dtype>(dim, scale[0], top_data);
+      } else {
+        // NOLINT_NEXT_LINE(whitespace/operators)
+        MulBsx<Dtype> <<<CAFFE_GET_BLOCKS(dim), CAFFE_CUDA_NUM_THREADS>>>(
+            dim, top_data, scale, channels, spatial_dim, CblasTrans,
+            top_data);
+        CUDA_POST_KERNEL_CHECK;
+      }
+      bottom_data += dim;
+      top_data += dim;
+    }
+#endif //USE_CUDA
+  } else {
+#ifdef USE_GREENTEA
+    viennacl::ocl::context &ctx = viennacl::ocl::get_context(
+        this->device_->id());
+
+    viennacl::ocl::program &program = this->device_->program();
+    if (across_spatial_) {
+      // need to index it
+      norm_data = norm_.mutable_cpu_data();
+    } else {
+      norm_data = norm_.mutable_gpu_data();
+      // add eps to avoid overflow
+      greentea_gpu_set<Dtype>(this->device_->id(), norm_.count(),
+                              static_cast<Dtype>(eps_), (cl_mem)norm_data, 0);
+    }
+    const Dtype* scale;
+    if (channel_shared_) {
+      scale = this->blobs_[0]->cpu_data();
+    } else {
+      scale = this->blobs_[0]->gpu_data();
+    }
+    const Dtype* sum_channel_multiplier = sum_channel_multiplier_.gpu_data();
+    int num = bottom[0]->num();
+    int dim = bottom[0]->count() / num;
+    int spatial_dim = bottom[0]->height() * bottom[0]->width();
+    int channels = bottom[0]->channels();
+    for (int n = 0; n < num; ++n) {
+      greentea_gpu_powx<Dtype>(this->device_->id(), dim, (cl_mem)bottom_data,
+                               n*dim, Dtype(2), (cl_mem)buffer_data, 0);
+      if (across_spatial_) {
+        Dtype normsqr;
+        greentea_gpu_asum<Dtype>(this->device_->id(), dim, (cl_mem)buffer_data,
+                                 0, &normsqr);
+        // add eps to avoid overflow
+        norm_data[n] = pow(normsqr+eps_, Dtype(0.5));
+        greentea_gpu_scale<Dtype>(this->device_->id(), dim, Dtype(1.0 / norm_data[n]),
+                                  (cl_mem)bottom_data, n*dim,
+                                  (cl_mem)top_data, n*dim);
+      } else {
+        // compute norm
+        greentea_gpu_gemv<Dtype>(this->device_->id(), CblasTrans, channels, spatial_dim,
+                                 1., (cl_mem)buffer_data, 0, (cl_mem)sum_channel_multiplier,
+                                 0, 1., (cl_mem)norm_data, n*spatial_dim);
+        greentea_gpu_powx<Dtype>(this->device_->id(), spatial_dim, (cl_mem)norm_data,
+                                 n*spatial_dim, 0.5, (cl_mem)norm_data, n*spatial_dim);
+        // scale the layer
+        //TODO
+        // NOLINT_NEXT_LINE(whitespace/operators)
+        // DivBsx<Dtype> <<<CAFFE_GET_BLOCKS(dim), CAFFE_CUDA_NUM_THREADS>>>(
+        //     dim, bottom_data, norm_data, channels, spatial_dim, CblasNoTrans,
+        //    top_data);
+        viennacl::ocl::kernel &oclk_divbsx = program.get_kernel(
+            CL_KERNEL_SELECT("DivBsx"));
+        viennacl::ocl::enqueue(
+            oclk_divbsx(dim,
+            WrapHandle((cl_mem) bottom_data, &ctx),
+            n*dim,
+            WrapHandle((cl_mem)norm_data, &ctx),
+            n*spatial_dim,
+            channels,
+            spatial_dim,
+            WrapHandle((cl_mem) top_data, &ctx),
+            n*dim),
+            ctx.get_queue());
+      }
+      // scale the output
+      if (channel_shared_) {
+        greentea_gpu_scal<Dtype>(this->device_->id(), dim, scale[0], (cl_mem)top_data, n*dim);
+      } else {
+        // NOLINT_NEXT_LINE(whitespace/operators)
+        // MulBsx<Dtype> <<<CAFFE_GET_BLOCKS(dim), CAFFE_CUDA_NUM_THREADS>>>(
+        //     dim, top_data, scale, channels, spatial_dim, CblasTrans,
+        //     top_data);
+        viennacl::ocl::kernel &oclk_mulbsx = program.get_kernel(
+            CL_KERNEL_SELECT("MulBsx"));
+        viennacl::ocl::enqueue(
+            oclk_mulbsx(dim,
+            WrapHandle((cl_mem) top_data, &ctx),
+            n*dim,
+            WrapHandle((cl_mem) scale, &ctx),
+            channels,
+            spatial_dim,
+            1,
+            WrapHandle((cl_mem) top_data, &ctx),
+            n*dim),
+            ctx.get_queue());
+      }
+    }
+#endif //USE_GREENTEA
   }
 }
 
 template <typename Dtype>
 void NormalizeLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
     const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+#ifdef USE_CUDA
   const Dtype* top_diff = top[0]->gpu_diff();
   const Dtype* top_data = top[0]->gpu_data();
   const Dtype* bottom_data = bottom[0]->mutable_gpu_data();
@@ -213,10 +307,12 @@ void NormalizeLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
       bottom_diff += dim;
     }
   }
+#else
+  this->Backward_cpu(top, propagate_down, bottom);
+#endif //USE_CUDA
 }
 
 INSTANTIATE_LAYER_GPU_FUNCS(NormalizeLayer);
 
 
 }  // namespace caffe
-#endif // USE_CUDA


### PR DESCRIPTION
Hi @gongzg 
This patch enable initial ocl version of permute and normalize layers and can pass the corresponding test cased.