### PR TITLE
OCL version of Detection output layer enabled

### DIFF
--- a/include/caffe/layers/detection_output_layer.hpp
+++ b/include/caffe/layers/detection_output_layer.hpp
@@ -61,21 +61,17 @@ class DetectionOutputLayer : public Layer<Dtype> {
    */
   virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
-#ifdef USE_CUDA
   virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
-#endif
   /// @brief Not implemented
   virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
     NOT_IMPLEMENTED;
   }
-#ifdef USE_CUDA
   virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
     NOT_IMPLEMENTED;
   }
-#endif
 
   int num_classes_;
   bool share_location_;
@@ -91,6 +87,7 @@ class DetectionOutputLayer : public Layer<Dtype> {
 
   float nms_threshold_;
   int top_k_;
+  float eta_;
 
   bool need_save_;
   string output_directory_;

--- a/include/caffe/test/test_caffe_main.hpp
+++ b/include/caffe/test/test_caffe_main.hpp
@@ -81,6 +81,10 @@ typedef ::testing::Types<CPUDevice<float>,
                          GPUDevice<float> >
                          TestFloatAndDevices;
 
+typedef ::testing::Types<GPUDevice<float>,
+                          GPUDevice<double> >
+                          TestGPUDtypesAndDevices;
+
 #endif
 
 #if defined(USE_LEVELDB) && defined(USE_LMDB)

--- a/include/caffe/util/bbox_util.hpp
+++ b/include/caffe/util/bbox_util.hpp
@@ -452,7 +452,7 @@ __host__ __device__ Dtype BBoxSizeGPU(const Dtype* bbox,
 template <typename Dtype>
 __host__ __device__ Dtype JaccardOverlapGPU(const Dtype* bbox1,
                                             const Dtype* bbox2);
-
+#endif //USE_CUDA
 template <typename Dtype>
 void DecodeBBoxesGPU(const int nthreads,
           const Dtype* loc_data, const Dtype* prior_data,
@@ -466,6 +466,7 @@ void PermuteDataGPU(const int nthreads,
           const Dtype* data, const int num_classes, const int num_data,
           const int num_dim, Dtype* new_data);
 
+#ifdef USE_CUDA
 template <typename Dtype>
 void SoftMaxGPU(const Dtype* data, const int outer_num, const int channels,
     const int inner_num, Dtype* prob);
@@ -489,7 +490,7 @@ template <typename Dtype>
 void GetDetectionsGPU(const Dtype* bbox_data, const Dtype* conf_data,
           const int image_id, const int label, const vector<int>& indices,
           const bool clip_bbox, Blob<Dtype>* detection_blob);
-#endif // USE_CUDA
+#endif //USE_CUDA
 #endif  // !CPU_ONLY
 
 #ifdef USE_OPENCV

--- a/include/caffe/util/bbox_util.hpp
+++ b/include/caffe/util/bbox_util.hpp
@@ -134,7 +134,7 @@ void DecodeBBoxesAll(const vector<LabelBBox>& all_loc_pred,
     const int num, const bool share_location,
     const int num_loc_classes, const int background_label_id,
     const CodeType code_type, const bool variance_encoded_in_target,
-    vector<LabelBBox>* all_decode_bboxes);
+    const bool clip, vector<LabelBBox>* all_decode_bboxes);
 
 // Match prediction bboxes with ground truth bboxes.
 void MatchBBox(const vector<NormalizedBBox>& gt,
@@ -278,7 +278,7 @@ void GetConfidenceScores(const Dtype* conf_data, const int num,
       const int num_preds_per_class, const int num_classes,
       const bool class_major, vector<map<int, vector<float> > >* conf_scores);
 
-// Get max confidence scores for each prior from conf_data.
+// Compute the confidence loss for each prior from conf_data.
 //    conf_data: num x num_preds_per_class * num_classes blob.
 //    num: the number of images.
 //    num_preds_per_class: number of predictions per class.
@@ -353,10 +353,11 @@ void GetDetectionResults(const Dtype* det_data, const int num_det,
 
 // Get top_k scores with corresponding indices.
 //    scores: a set of scores.
+//    indices: a set of corresponding indices.
 //    top_k: if -1, keep all; otherwise, keep at most top_k.
 //    score_index_vec: store the sorted (score, index) pair.
-void GetTopKScoreIndex(const vector<float>& scores, const int top_k,
-                         vector<pair<float, int> >* score_index_vec);
+void GetTopKScoreIndex(const vector<float>& scores, const vector<int>& indices,
+      const int top_k, vector<pair<float, int> >* score_index_vec);
 
 // Get max scores with corresponding indices.
 //    scores: a set of scores.
@@ -376,10 +377,18 @@ template <typename Dtype>
 void GetMaxScoreIndex(const Dtype* scores, const int num, const float threshold,
       const int top_k, vector<pair<Dtype, int> >* score_index_vec);
 
+// Get max scores with corresponding indices.
+//    scores: a set of scores.
+//    threshold: only consider scores higher than the threshold.
+//    top_k: if -1, keep all; otherwise, keep at most top_k.
+//    score_index_vec: store the sorted (score, index) pair.
+void GetMaxScoreIndex(const vector<float>& scores, const float threshold,
+      const int top_k, vector<pair<float, int> >* score_index_vec);
+
 // Do non maximum suppression given bboxes and scores.
 //    bboxes: a set of bounding boxes.
 //    scores: a set of corresponding confidences.
-//    threshold: the threshold used in non maximu suppression.
+//    threshold: the threshold used in non maximum suppression.
 //    top_k: if not -1, keep at most top_k picked indices.
 //    reuse_overlaps: if true, use and update overlaps; otherwise, always
 //      compute overlap.
@@ -402,11 +411,13 @@ void ApplyNMS(const bool* overlapped, const int num, vector<int>* indices);
 //    scores: a set of corresponding confidences.
 //    score_threshold: a threshold used to filter detection results.
 //    nms_threshold: a threshold used in non maximum suppression.
+//    eta: adaptation rate for nms threshold (see Piotr's paper).
 //    top_k: if not -1, keep at most top_k picked indices.
 //    indices: the kept indices of bboxes after nms.
 void ApplyNMSFast(const vector<NormalizedBBox>& bboxes,
       const vector<float>& scores, const float score_threshold,
-      const float nms_threshold, const int top_k, vector<int>* indices);
+      const float nms_threshold, const float eta, const int top_k,
+      vector<int>* indices);
 
 // Do non maximum suppression based on raw bboxes and scores data.
 // Inspired by Piotr Dollar's NMS implementation in EdgeBox.
@@ -466,7 +477,6 @@ void PermuteDataGPU(const int nthreads,
           const Dtype* data, const int num_classes, const int num_data,
           const int num_dim, Dtype* new_data);
 
-#ifdef USE_CUDA
 template <typename Dtype>
 void SoftMaxGPU(const Dtype* data, const int outer_num, const int channels,
     const int inner_num, Dtype* prob);
@@ -480,7 +490,7 @@ template <typename Dtype>
 void ComputeOverlappedByIdxGPU(const int nthreads,
           const Dtype* bbox_data, const Dtype overlap_threshold,
           const int* idx, const int num_idx, bool* overlapped_data);
-
+#ifdef USE_CUDA
 template <typename Dtype>
 void ApplyNMSGPU(const Dtype* bbox_data, const Dtype* conf_data,
           const int num_bboxes, const float confidence_threshold,
@@ -490,7 +500,15 @@ template <typename Dtype>
 void GetDetectionsGPU(const Dtype* bbox_data, const Dtype* conf_data,
           const int image_id, const int label, const vector<int>& indices,
           const bool clip_bbox, Blob<Dtype>* detection_blob);
-#endif //USE_CUDA
+
+template <typename Dtype>
+  void ComputeConfLossGPU(const Blob<Dtype>& conf_blob, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const int background_label_id, const ConfLossType loss_type,
+      const vector<map<int, vector<int> > >& all_match_indices,
+      const map<int, vector<NormalizedBBox> >& all_gt_bboxes,
+      vector<vector<float> >* all_conf_loss);
+#endif // USE_CUDA
 #endif  // !CPU_ONLY
 
 #ifdef USE_OPENCV

--- a/src/caffe/greentea/cl_kernels.cpp
+++ b/src/caffe/greentea/cl_kernels.cpp
@@ -279,6 +279,162 @@ static std::vector<std::vector<std::string>> cl_kernels{
 "#include \"header.cl\"",    // NOLINT
 "#endif",    // NOLINT
 "",    // NOLINT
+"__kernel void TEMPLATE(DecodeBBoxesCORNER, Dtype)(const int nthreads,",    // NOLINT
+"__global const Dtype* loc_data, __global const Dtype* prior_data,",    // NOLINT
+"const int variance_encoded_in_target,",    // NOLINT
+"const int num_priors, const int share_location,",    // NOLINT
+"const int num_loc_classes, const int background_label_id,",    // NOLINT
+"const int clip_bbox, __global Dtype* bbox_data) {",    // NOLINT
+"",    // NOLINT
+"for (int index = get_global_id(0); index < nthreads; index += get_global_size(0)) {",    // NOLINT
+"const int i = index % 4;",    // NOLINT
+"const int c = (index / 4) % num_loc_classes;",    // NOLINT
+"const int d = (index / 4 / num_loc_classes) % num_priors;",    // NOLINT
+"if (!share_location && c == background_label_id) {",    // NOLINT
+"// Ignore background class if not share_location.",    // NOLINT
+"return;",    // NOLINT
+"}",    // NOLINT
+"const int pi = d * 4;",    // NOLINT
+"const int vi = pi + num_priors * 4;",    // NOLINT
+"if (variance_encoded_in_target) {",    // NOLINT
+"// variance is encoded in target, we simply need to add the offset",    // NOLINT
+"// predictions.",    // NOLINT
+"bbox_data[index] = prior_data[pi + i] + loc_data[index];",    // NOLINT
+"} else {",    // NOLINT
+"// variance is encoded in bbox, we need to scale the offset accordingly.",    // NOLINT
+"bbox_data[index] =",    // NOLINT
+"prior_data[pi + i] + loc_data[index] * prior_data[vi + i];",    // NOLINT
+"}",    // NOLINT
+"if (clip_bbox) {",    // NOLINT
+"bbox_data[index] = max(min(bbox_data[index], (Dtype)1.), (Dtype)0.);",    // NOLINT
+"}",    // NOLINT
+"}",    // NOLINT
+"}",    // NOLINT
+"",    // NOLINT
+"__kernel void TEMPLATE(DecodeBBoxesCENTER_SIZE, Dtype)(const int nthreads,",    // NOLINT
+"__global const Dtype* loc_data, __global const Dtype* prior_data,",    // NOLINT
+"const int variance_encoded_in_target,",    // NOLINT
+"const int num_priors, const int share_location,",    // NOLINT
+"const int num_loc_classes, const int background_label_id,",    // NOLINT
+"const int clip_bbox, __global Dtype* bbox_data) {",    // NOLINT
+"",    // NOLINT
+"for (int index = get_global_id(0); index < nthreads; index += get_global_size(0)) {",    // NOLINT
+"const int i = index % 4;",    // NOLINT
+"const int c = (index / 4) % num_loc_classes;",    // NOLINT
+"const int d = (index / 4 / num_loc_classes) % num_priors;",    // NOLINT
+"if (!share_location && c == background_label_id) {",    // NOLINT
+"// Ignore background class if not share_location.",    // NOLINT
+"return;",    // NOLINT
+"}",    // NOLINT
+"const int pi = d * 4;",    // NOLINT
+"const int vi = pi + num_priors * 4;",    // NOLINT
+"const Dtype p_xmin = prior_data[pi];",    // NOLINT
+"const Dtype p_ymin = prior_data[pi + 1];",    // NOLINT
+"const Dtype p_xmax = prior_data[pi + 2];",    // NOLINT
+"const Dtype p_ymax = prior_data[pi + 3];",    // NOLINT
+"const Dtype prior_width = p_xmax - p_xmin;",    // NOLINT
+"const Dtype prior_height = p_ymax - p_ymin;",    // NOLINT
+"const Dtype prior_center_x = (p_xmin + p_xmax) / 2.;",    // NOLINT
+"const Dtype prior_center_y = (p_ymin + p_ymax) / 2.;",    // NOLINT
+"",    // NOLINT
+"const Dtype xmin = loc_data[index - i];",    // NOLINT
+"const Dtype ymin = loc_data[index - i + 1];",    // NOLINT
+"const Dtype xmax = loc_data[index - i + 2];",    // NOLINT
+"const Dtype ymax = loc_data[index - i + 3];",    // NOLINT
+"",    // NOLINT
+"Dtype decode_bbox_center_x, decode_bbox_center_y;",    // NOLINT
+"Dtype decode_bbox_width, decode_bbox_height;",    // NOLINT
+"if (variance_encoded_in_target) {",    // NOLINT
+"// variance is encoded in target, we simply need to retore the offset",    // NOLINT
+"// predictions.",    // NOLINT
+"decode_bbox_center_x = xmin * prior_width + prior_center_x;",    // NOLINT
+"decode_bbox_center_y = ymin * prior_height + prior_center_y;",    // NOLINT
+"decode_bbox_width = exp(xmax) * prior_width;",    // NOLINT
+"decode_bbox_height = exp(ymax) * prior_height;",    // NOLINT
+"} else {",    // NOLINT
+"// variance is encoded in bbox, we need to scale the offset accordingly.",    // NOLINT
+"decode_bbox_center_x =",    // NOLINT
+"prior_data[vi] * xmin * prior_width + prior_center_x;",    // NOLINT
+"decode_bbox_center_y =",    // NOLINT
+"prior_data[vi + 1] * ymin * prior_height + prior_center_y;",    // NOLINT
+"decode_bbox_width =",    // NOLINT
+"exp(prior_data[vi + 2] * xmax) * prior_width;",    // NOLINT
+"decode_bbox_height =",    // NOLINT
+"exp(prior_data[vi + 3] * ymax) * prior_height;",    // NOLINT
+"}",    // NOLINT
+"",    // NOLINT
+"switch (i) {",    // NOLINT
+"case 0:",    // NOLINT
+"bbox_data[index] = decode_bbox_center_x - decode_bbox_width / 2.;",    // NOLINT
+"break;",    // NOLINT
+"case 1:",    // NOLINT
+"bbox_data[index] = decode_bbox_center_y - decode_bbox_height / 2.;",    // NOLINT
+"break;",    // NOLINT
+"case 2:",    // NOLINT
+"bbox_data[index] = decode_bbox_center_x + decode_bbox_width / 2.;",    // NOLINT
+"break;",    // NOLINT
+"case 3:",    // NOLINT
+"bbox_data[index] = decode_bbox_center_y + decode_bbox_height / 2.;",    // NOLINT
+"break;",    // NOLINT
+"}",    // NOLINT
+"if (clip_bbox) {",    // NOLINT
+"bbox_data[index] = max(min(bbox_data[index], (Dtype)1.), (Dtype)0.);",    // NOLINT
+"}",    // NOLINT
+"}",    // NOLINT
+"}",    // NOLINT
+"",    // NOLINT
+"__kernel void TEMPLATE(DecodeBBoxesCORNER_SIZE, Dtype)(const int nthreads,",    // NOLINT
+"__global const Dtype* loc_data, __global const Dtype* prior_data,",    // NOLINT
+"const int variance_encoded_in_target,",    // NOLINT
+"const int num_priors, const int share_location,",    // NOLINT
+"const int num_loc_classes, const int background_label_id,",    // NOLINT
+"const int clip_bbox, __global Dtype* bbox_data) {",    // NOLINT
+"",    // NOLINT
+"for (int index = get_global_id(0); index < nthreads; index += get_global_size(0)) {",    // NOLINT
+"const int i = index % 4;",    // NOLINT
+"const int c = (index / 4) % num_loc_classes;",    // NOLINT
+"const int d = (index / 4 / num_loc_classes) % num_priors;",    // NOLINT
+"if (!share_location && c == background_label_id) {",    // NOLINT
+"// Ignore background class if not share_location.",    // NOLINT
+"return;",    // NOLINT
+"}",    // NOLINT
+"const int pi = d * 4;",    // NOLINT
+"const int vi = pi + num_priors * 4;",    // NOLINT
+"const Dtype p_xmin = prior_data[pi];",    // NOLINT
+"const Dtype p_ymin = prior_data[pi + 1];",    // NOLINT
+"const Dtype p_xmax = prior_data[pi + 2];",    // NOLINT
+"const Dtype p_ymax = prior_data[pi + 3];",    // NOLINT
+"const Dtype prior_width = p_xmax - p_xmin;",    // NOLINT
+"const Dtype prior_height = p_ymax - p_ymin;",    // NOLINT
+"Dtype p_size;",    // NOLINT
+"if (i == 0 || i == 2) {",    // NOLINT
+"p_size = prior_width;",    // NOLINT
+"} else {",    // NOLINT
+"p_size = prior_height;",    // NOLINT
+"}",    // NOLINT
+"if (variance_encoded_in_target) {",    // NOLINT
+"// variance is encoded in target, we simply need to add the offset",    // NOLINT
+"// predictions.",    // NOLINT
+"bbox_data[index] = prior_data[pi + i] + loc_data[index] * p_size;",    // NOLINT
+"} else {",    // NOLINT
+"// variance is encoded in bbox, we need to scale the offset accordingly.",    // NOLINT
+"bbox_data[index] =",    // NOLINT
+"prior_data[pi + i] + loc_data[index] * prior_data[vi + i] * p_size;",    // NOLINT
+"}",    // NOLINT
+"if (clip_bbox) {",    // NOLINT
+"bbox_data[index] = max(min(bbox_data[index], (Dtype)1.), (Dtype)0.);",    // NOLINT
+"}",    // NOLINT
+"}",    // NOLINT
+"}",    // NOLINT
+"",    // NOLINT
+"",    // NOLINT
+"",    // NOLINT
+"",    // NOLINT
+""},   // NOLINT
+    {"#ifndef __OPENCL_VERSION__",    // NOLINT
+"#include \"header.cl\"",    // NOLINT
+"#endif",    // NOLINT
+"",    // NOLINT
 "__kernel void TEMPLATE(null_kernel,Dtype)(Dtype arg) {",    // NOLINT
 "Dtype out = arg;",    // NOLINT
 "}",    // NOLINT
@@ -7012,6 +7168,7 @@ static std::string cl_kernel_names[] = {
     "auxiliary",   // NOLINT
     "batch_norm",   // NOLINT
     "batch_reindex",   // NOLINT
+    "bbox_util",   // NOLINT
     "benchmark",   // NOLINT
     "bias",   // NOLINT
     "bnll",   // NOLINT

--- a/src/caffe/greentea/cl_kernels.cpp
+++ b/src/caffe/greentea/cl_kernels.cpp
@@ -427,6 +427,20 @@ static std::vector<std::vector<std::string>> cl_kernels{
 "}",    // NOLINT
 "}",    // NOLINT
 "",    // NOLINT
+"__kernel void TEMPLATE(PermuteData, Dtype)(const int nthreads,",    // NOLINT
+"__global const Dtype* data, const int num_classes, const int num_data,",    // NOLINT
+"const int num_dim, __global Dtype* new_data) {",    // NOLINT
+"for (int index = get_global_id(0); index < nthreads; index += get_global_size(0)) {",    // NOLINT
+"const int i = index % num_dim;",    // NOLINT
+"const int c = (index / num_dim) % num_classes;",    // NOLINT
+"const int d = (index / num_dim / num_classes) % num_data;",    // NOLINT
+"const int n = index / num_dim / num_classes / num_data;",    // NOLINT
+"const int new_index = ((n * num_classes + c) * num_data + d) * num_dim + i;",    // NOLINT
+"new_data[new_index] = data[index];",    // NOLINT
+"}",    // NOLINT
+"}",    // NOLINT
+"",    // NOLINT
+"",    // NOLINT
 "",    // NOLINT
 "",    // NOLINT
 "",    // NOLINT

--- a/src/caffe/greentea/cl_kernels/bbox_util.cl
+++ b/src/caffe/greentea/cl_kernels/bbox_util.cl
@@ -150,6 +150,20 @@ __kernel void TEMPLATE(DecodeBBoxesCORNER_SIZE, Dtype)(const int nthreads,
   }
 }
 
+__kernel void TEMPLATE(PermuteData, Dtype)(const int nthreads,
+          __global const Dtype* data, const int num_classes, const int num_data,
+          const int num_dim, __global Dtype* new_data) {
+  for (int index = get_global_id(0); index < nthreads; index += get_global_size(0)) {
+    const int i = index % num_dim;
+    const int c = (index / num_dim) % num_classes;
+    const int d = (index / num_dim / num_classes) % num_data;
+    const int n = index / num_dim / num_classes / num_data;
+    const int new_index = ((n * num_classes + c) * num_data + d) * num_dim + i;
+    new_data[new_index] = data[index];
+  }
+}
+
+
 
 
 

--- a/src/caffe/greentea/cl_kernels/bbox_util.cl
+++ b/src/caffe/greentea/cl_kernels/bbox_util.cl
@@ -1,0 +1,155 @@
+#ifndef __OPENCL_VERSION__
+#include "header.cl"
+#endif
+
+__kernel void TEMPLATE(DecodeBBoxesCORNER, Dtype)(const int nthreads,
+          __global const Dtype* loc_data, __global const Dtype* prior_data,
+          const int variance_encoded_in_target,
+          const int num_priors, const int share_location,
+          const int num_loc_classes, const int background_label_id,
+          const int clip_bbox, __global Dtype* bbox_data) {
+
+  for (int index = get_global_id(0); index < nthreads; index += get_global_size(0)) {
+    const int i = index % 4;
+    const int c = (index / 4) % num_loc_classes;
+    const int d = (index / 4 / num_loc_classes) % num_priors;
+    if (!share_location && c == background_label_id) {
+      // Ignore background class if not share_location.
+      return;
+    }
+    const int pi = d * 4;
+    const int vi = pi + num_priors * 4;
+    if (variance_encoded_in_target) {
+      // variance is encoded in target, we simply need to add the offset
+      // predictions.
+      bbox_data[index] = prior_data[pi + i] + loc_data[index];
+    } else {
+      // variance is encoded in bbox, we need to scale the offset accordingly.
+      bbox_data[index] =
+        prior_data[pi + i] + loc_data[index] * prior_data[vi + i];
+    }
+    if (clip_bbox) {
+      bbox_data[index] = max(min(bbox_data[index], (Dtype)1.), (Dtype)0.);
+    }
+  }
+}
+
+__kernel void TEMPLATE(DecodeBBoxesCENTER_SIZE, Dtype)(const int nthreads,
+          __global const Dtype* loc_data, __global const Dtype* prior_data,
+          const int variance_encoded_in_target,
+          const int num_priors, const int share_location,
+          const int num_loc_classes, const int background_label_id,
+          const int clip_bbox, __global Dtype* bbox_data) {
+
+  for (int index = get_global_id(0); index < nthreads; index += get_global_size(0)) {
+    const int i = index % 4;
+    const int c = (index / 4) % num_loc_classes;
+    const int d = (index / 4 / num_loc_classes) % num_priors;
+    if (!share_location && c == background_label_id) {
+      // Ignore background class if not share_location.
+      return;
+    }
+    const int pi = d * 4;
+    const int vi = pi + num_priors * 4;
+    const Dtype p_xmin = prior_data[pi];
+    const Dtype p_ymin = prior_data[pi + 1];
+    const Dtype p_xmax = prior_data[pi + 2];
+    const Dtype p_ymax = prior_data[pi + 3];
+    const Dtype prior_width = p_xmax - p_xmin;
+    const Dtype prior_height = p_ymax - p_ymin;
+    const Dtype prior_center_x = (p_xmin + p_xmax) / 2.;
+    const Dtype prior_center_y = (p_ymin + p_ymax) / 2.;
+
+    const Dtype xmin = loc_data[index - i];
+    const Dtype ymin = loc_data[index - i + 1];
+    const Dtype xmax = loc_data[index - i + 2];
+    const Dtype ymax = loc_data[index - i + 3];
+
+    Dtype decode_bbox_center_x, decode_bbox_center_y;
+    Dtype decode_bbox_width, decode_bbox_height;
+    if (variance_encoded_in_target) {
+      // variance is encoded in target, we simply need to retore the offset
+      // predictions.
+      decode_bbox_center_x = xmin * prior_width + prior_center_x;
+      decode_bbox_center_y = ymin * prior_height + prior_center_y;
+      decode_bbox_width = exp(xmax) * prior_width;
+      decode_bbox_height = exp(ymax) * prior_height;
+    } else {
+      // variance is encoded in bbox, we need to scale the offset accordingly.
+      decode_bbox_center_x =
+        prior_data[vi] * xmin * prior_width + prior_center_x;
+      decode_bbox_center_y =
+        prior_data[vi + 1] * ymin * prior_height + prior_center_y;
+      decode_bbox_width =
+        exp(prior_data[vi + 2] * xmax) * prior_width;
+      decode_bbox_height =
+        exp(prior_data[vi + 3] * ymax) * prior_height;
+    }
+
+    switch (i) {
+      case 0:
+        bbox_data[index] = decode_bbox_center_x - decode_bbox_width / 2.;
+        break;
+      case 1:
+        bbox_data[index] = decode_bbox_center_y - decode_bbox_height / 2.;
+        break;
+      case 2:
+        bbox_data[index] = decode_bbox_center_x + decode_bbox_width / 2.;
+        break;
+      case 3:
+        bbox_data[index] = decode_bbox_center_y + decode_bbox_height / 2.;
+        break;
+    }
+    if (clip_bbox) {
+      bbox_data[index] = max(min(bbox_data[index], (Dtype)1.), (Dtype)0.);
+    }
+  }
+}
+
+__kernel void TEMPLATE(DecodeBBoxesCORNER_SIZE, Dtype)(const int nthreads,
+          __global const Dtype* loc_data, __global const Dtype* prior_data,
+          const int variance_encoded_in_target,
+          const int num_priors, const int share_location,
+          const int num_loc_classes, const int background_label_id,
+          const int clip_bbox, __global Dtype* bbox_data) {
+
+  for (int index = get_global_id(0); index < nthreads; index += get_global_size(0)) {
+    const int i = index % 4;
+    const int c = (index / 4) % num_loc_classes;
+    const int d = (index / 4 / num_loc_classes) % num_priors;
+    if (!share_location && c == background_label_id) {
+      // Ignore background class if not share_location.
+      return;
+    }
+    const int pi = d * 4;
+    const int vi = pi + num_priors * 4;
+    const Dtype p_xmin = prior_data[pi];
+    const Dtype p_ymin = prior_data[pi + 1];
+    const Dtype p_xmax = prior_data[pi + 2];
+    const Dtype p_ymax = prior_data[pi + 3];
+    const Dtype prior_width = p_xmax - p_xmin;
+    const Dtype prior_height = p_ymax - p_ymin;
+    Dtype p_size;
+    if (i == 0 || i == 2) {
+      p_size = prior_width;
+    } else {
+      p_size = prior_height;
+    }
+    if (variance_encoded_in_target) {
+      // variance is encoded in target, we simply need to add the offset
+      // predictions.
+      bbox_data[index] = prior_data[pi + i] + loc_data[index] * p_size;
+    } else {
+      // variance is encoded in bbox, we need to scale the offset accordingly.
+      bbox_data[index] =
+      prior_data[pi + i] + loc_data[index] * prior_data[vi + i] * p_size;
+    }
+    if (clip_bbox) {
+      bbox_data[index] = max(min(bbox_data[index], (Dtype)1.), (Dtype)0.);
+    }
+  }
+}
+
+
+
+

--- a/src/caffe/layers/detection_output_layer.cu
+++ b/src/caffe/layers/detection_output_layer.cu
@@ -13,7 +13,6 @@
 #include "boost/foreach.hpp"
 
 #include "caffe/layers/detection_output_layer.hpp"
-#ifdef USE_CUDA
 namespace caffe {
 
 template <typename Dtype>
@@ -302,4 +301,3 @@ void DetectionOutputLayer<Dtype>::Forward_gpu(
 INSTANTIATE_LAYER_GPU_FUNCS(DetectionOutputLayer);
 
 }  // namespace caffe
-#endif //USE_CUDA

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -995,6 +995,8 @@ message NonMaximumSuppressionParameter {
   optional float nms_threshold = 1 [default = 0.3];
   // Maximum number of results to be kept.
   optional int32 top_k = 2;
+  // Parameter for adaptive nms.
+  optional float eta = 3 [default = 1.0];
 }
 
 message SaveOutputParameter {

--- a/src/caffe/util/bbox_util.cpp
+++ b/src/caffe/util/bbox_util.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <csignal>
 #include <ctime>
+#include <functional>
 #include <map>
 #include <set>
 #include <string>
@@ -554,7 +555,7 @@ void DecodeBBoxesAll(const vector<LabelBBox>& all_loc_preds,
     const int num, const bool share_location,
     const int num_loc_classes, const int background_label_id,
     const CodeType code_type, const bool variance_encoded_in_target,
-    vector<LabelBBox>* all_decode_bboxes) {
+    const bool clip, vector<LabelBBox>* all_decode_bboxes) {
   CHECK_EQ(all_loc_preds.size(), num);
   all_decode_bboxes->clear();
   all_decode_bboxes->resize(num);
@@ -574,7 +575,7 @@ void DecodeBBoxesAll(const vector<LabelBBox>& all_loc_preds,
       const vector<NormalizedBBox>& label_loc_preds =
           all_loc_preds[i].find(label)->second;
       DecodeBBoxes(prior_bboxes, prior_variances,
-                   code_type, variance_encoded_in_target, false,
+                   code_type, variance_encoded_in_target, clip,
                    label_loc_preds, &(decode_bboxes[label]));
     }
   }
@@ -835,7 +836,7 @@ int CountNumMatches(const vector<map<int, vector<int> > >& all_match_indices,
 }
 
 inline bool IsEligibleMining(const MiningType mining_type, const int match_idx,
-                             const float match_overlap, const float neg_overlap) {
+    const float match_overlap, const float neg_overlap) {
   if (mining_type == MultiBoxLossParameter_MiningType_MAX_NEGATIVE) {
     return match_idx == -1 && match_overlap < neg_overlap;
   } else if (mining_type == MultiBoxLossParameter_MiningType_HARD_EXAMPLE) {
@@ -891,14 +892,20 @@ void MineHardExamples(const Blob<Dtype>& conf_blob,
   const int sample_size = multibox_loss_param.sample_size();
   // Compute confidence losses based on matching results.
   vector<vector<float> > all_conf_loss;
-#ifndef USE_CUDA
+#ifdef CPU_ONLY
   ComputeConfLoss(conf_blob.cpu_data(), num, num_priors, num_classes,
       background_label_id, conf_loss_type, *all_match_indices, all_gt_bboxes,
       &all_conf_loss);
 #else
+#ifdef USE_CUDA
   ComputeConfLossGPU(conf_blob, num, num_priors, num_classes,
       background_label_id, conf_loss_type, *all_match_indices, all_gt_bboxes,
       &all_conf_loss);
+#else
+  ComputeConfLoss(conf_blob.cpu_data(), num, num_priors, num_classes,
+      background_label_id, conf_loss_type, *all_match_indices, all_gt_bboxes,
+      &all_conf_loss);
+#endif
 #endif
   vector<vector<float> > all_loc_loss;
   if (mining_type == MultiBoxLossParameter_MiningType_HARD_EXAMPLE) {
@@ -1389,55 +1396,6 @@ template void GetConfidenceScores(const float* conf_data, const int num,
 template void GetConfidenceScores(const double* conf_data, const int num,
       const int num_preds_per_class, const int num_classes,
       const bool class_major, vector<map<int, vector<float> > >* conf_preds);
-
-template <typename Dtype>
-void GetMaxConfidenceScores(const Dtype* conf_data, const int num,
-      const int num_preds_per_class, const int num_classes,
-      const int background_label_id, const ConfLossType loss_type,
-      vector<vector<float> >* all_conf_loss) {
-  all_conf_loss->clear();
-  for (int i = 0; i < num; ++i) {
-    vector<float> conf_loss;
-    for (int p = 0; p < num_preds_per_class; ++p) {
-      int start_idx = p * num_classes;
-      int label = background_label_id;
-      Dtype loss = 0;
-      if (loss_type == MultiBoxLossParameter_ConfLossType_SOFTMAX) {
-        CHECK_GE(label, 0);
-        CHECK_LT(label, num_classes);
-        // Compute softmax probability.
-        // We need to subtract the max to avoid numerical issues.
-        Dtype maxval = -FLT_MAX;
-        for (int c = 0; c < num_classes; ++c) {
-          maxval = std::max<Dtype>(conf_data[start_idx + c], maxval);
-        }
-        Dtype sum = 0.;
-        for (int c = 0; c < num_classes; ++c) {
-          sum += std::exp(conf_data[start_idx + c] - maxval);
-        }
-        Dtype prob = std::exp(conf_data[start_idx + label] - maxval) / sum;
-        loss = -log(std::max(prob, Dtype(FLT_MIN)));
-      } else if (loss_type == MultiBoxLossParameter_ConfLossType_LOGISTIC) {
-        int target = 0;
-        for (int c = 0; c < num_classes; ++c) {
-          if (c == label) {
-            target = 1;
-          } else {
-            target = 0;
-          }
-          Dtype input = conf_data[start_idx + c];
-          loss -= input * (target - (input >= 0)) -
-              log(1 + exp(input - 2 * input * (input >= 0)));
-        }
-      } else {
-        LOG(FATAL) << "Unknown conf loss type.";
-      }
-      conf_loss.push_back(loss);
-    }
-    conf_data += num_preds_per_class * num_classes;
-    all_conf_loss->push_back(conf_loss);
-  }
-}
 
 template <typename Dtype>
 void ComputeConfLoss(const Dtype* conf_data, const int num,
@@ -1942,9 +1900,14 @@ void ApplyNMS(const bool* overlapped, const int num, vector<int>* indices) {
   }
 }
 
+inline int clamp(const int v, const int a, const int b) {
+  return v < a ? a : v > b ? b : v;
+}
+
 void ApplyNMSFast(const vector<NormalizedBBox>& bboxes,
       const vector<float>& scores, const float score_threshold,
-      const float nms_threshold, const int top_k, vector<int>* indices) {
+      const float nms_threshold, const float eta, const int top_k,
+      vector<int>* indices) {
   // Sanity check.
   CHECK_EQ(bboxes.size(), scores.size())
       << "bboxes and scores have different size.";
@@ -1954,6 +1917,7 @@ void ApplyNMSFast(const vector<NormalizedBBox>& bboxes,
   GetMaxScoreIndex(scores, score_threshold, top_k, &score_index_vec);
 
   // Do nms.
+  float adaptive_threshold = nms_threshold;
   indices->clear();
   while (score_index_vec.size() != 0) {
     const int idx = score_index_vec.front().second;
@@ -1962,7 +1926,7 @@ void ApplyNMSFast(const vector<NormalizedBBox>& bboxes,
       if (keep) {
         const int kept_idx = (*indices)[k];
         float overlap = JaccardOverlap(bboxes[idx], bboxes[kept_idx]);
-        keep = overlap <= nms_threshold;
+        keep = overlap <= adaptive_threshold;
       } else {
         break;
       }
@@ -1971,6 +1935,9 @@ void ApplyNMSFast(const vector<NormalizedBBox>& bboxes,
       indices->push_back(idx);
     }
     score_index_vec.erase(score_index_vec.begin());
+    if (keep && eta < 1 && adaptive_threshold > 0.5) {
+      adaptive_threshold *= eta;
+    }
   }
 }
 
@@ -2168,6 +2135,7 @@ vector<cv::Scalar> GetColors(const int n) {
   }
   return colors;
 }
+
 static clock_t start_clock = clock();
 static cv::VideoWriter cap_out;
 

--- a/src/caffe/util/bbox_util.cu
+++ b/src/caffe/util/bbox_util.cu
@@ -287,6 +287,19 @@ void PermuteDataGPU(const int nthreads,
 #endif //USE_CUDA
   } else {
 #ifdef USE_GREENTEA
+    viennacl::ocl::context &ctx = viennacl::ocl::get_context(
+        Caffe::GetDefaultDevice()->id());
+    viennacl::ocl::program &program = Caffe::GetDefaultDevice()->program();
+    viennacl::ocl::kernel &oclk_permute_data =
+        program.get_kernel(CL_KERNEL_SELECT("PermuteData"));
+    viennacl::ocl::enqueue(
+        oclk_permute_data(nthreads,
+        WrapHandle((cl_mem)data, &ctx),
+        num_classes,
+        num_data,
+        num_dim,
+        WrapHandle((cl_mem)new_data, &ctx)),
+        ctx.get_queue());
 #endif //USE_GREENTEA
   }
 }

--- a/src/caffe/util/bbox_util.cu
+++ b/src/caffe/util/bbox_util.cu
@@ -369,6 +369,7 @@ __global__ void kernel_channel_div(const int count,
     data[index] /= channel_sum[n * spatial_dim + s];
   }
 }
+#endif //USE_CUDA
 
 template <typename Dtype>
 void SoftMaxGPU(const Dtype* data, const int outer_num,
@@ -411,6 +412,7 @@ void SoftMaxGPU(const Dtype* data, const int outer_num,
 #endif //USE_CUDA
   } else {
 #ifdef USE_GREENTEA
+    NOT_IMPLEMENTED;
 #endif //USE_GREENTEA
   }
 }
@@ -419,7 +421,7 @@ template void SoftMaxGPU(const float* data, const int outer_num,
     const int channels, const int inner_num, float* prob);
 template void SoftMaxGPU(const double* data, const int outer_num,
     const int channels, const int inner_num, double* prob);
-#endif //USE_CUDA
+
 #ifdef USE_CUDA
 template <typename Dtype>
 __global__ void ComputeOverlappedKernel(const int nthreads,
@@ -445,7 +447,6 @@ __global__ void ComputeOverlappedKernel(const int nthreads,
   }
 }
 #endif //USE_CUDA
-#ifdef USE_CUDA
 template <typename Dtype>
 void ComputeOverlappedGPU(const int nthreads,
           const Dtype* bbox_data, const int num_bboxes, const int num_classes,
@@ -460,6 +461,7 @@ void ComputeOverlappedGPU(const int nthreads,
 #endif //USE_CUDA
   } else {
 #ifdef USE_GREENTEA
+    NOT_IMPLEMENTED;
 #endif //USE_GREENTEA
   }
 }
@@ -470,7 +472,7 @@ template void ComputeOverlappedGPU(const int nthreads,
 template void ComputeOverlappedGPU(const int nthreads,
           const double* bbox_data, const int num_bboxes, const int num_classes,
           const double overlap_threshold, bool* overlapped_data);
-#endif //USE_CUDA
+
 #ifdef USE_CUDA
 template <typename Dtype>
 __global__ void ComputeOverlappedByIdxKernel(const int nthreads,
@@ -494,7 +496,7 @@ __global__ void ComputeOverlappedByIdxKernel(const int nthreads,
   }
 }
 #endif //USE_CUDA
-#ifdef USE_CUDA
+
 template <typename Dtype>
 void ComputeOverlappedByIdxGPU(const int nthreads,
           const Dtype* bbox_data, const Dtype overlap_threshold,
@@ -509,6 +511,7 @@ void ComputeOverlappedByIdxGPU(const int nthreads,
 #endif //USE_CUDA
   } else {
 #ifdef USE_GREENTEA
+    NOT_IMPLEMENTED;
 #endif //USE_GREENTEA
   }
 }
@@ -519,7 +522,7 @@ template void ComputeOverlappedByIdxGPU(const int nthreads,
 template void ComputeOverlappedByIdxGPU(const int nthreads,
           const double* bbox_data, const double overlap_threshold,
           const int* idx, const int num_idx, bool* overlapped_data);
-#endif //USE_CUDA
+
 #ifdef USE_CUDA
 template <typename Dtype>
 void ApplyNMSGPU(const Dtype* bbox_data, const Dtype* conf_data,


### PR DESCRIPTION
Hi @gongzg ,

This patch enabled ocl version of detection_output_layer and pass the corresponding test cases.