### PR TITLE
Optimzed detection ouput layer

### DIFF
--- a/include/caffe/util/bbox_util.hpp
+++ b/include/caffe/util/bbox_util.hpp
@@ -375,7 +375,7 @@ void GetMaxScoreIndex(const vector<float>& scores, const float threshold,
 //    score_index_vec: store the sorted (score, index) pair.
 template <typename Dtype>
 void GetMaxScoreIndex(const Dtype* scores, const int num, const float threshold,
-      const int top_k, vector<pair<Dtype, int> >* score_index_vec);
+      const int top_k, vector<pair<Dtype, int> >& score_index_vec);
 
 // Get max scores with corresponding indices.
 //    scores: a set of scores.
@@ -433,7 +433,7 @@ void ApplyNMSFast(const vector<NormalizedBBox>& bboxes,
 template <typename Dtype>
 void ApplyNMSFast(const Dtype* bboxes, const Dtype* scores, const int num,
       const float score_threshold, const float nms_threshold,
-      const float eta, const int top_k, vector<int>* indices);
+      const float eta, const int top_k, vector<int>& indices);
 
 // Compute cumsum of a set of pairs.
 void CumSum(const vector<pair<float, int> >& pairs, vector<int>* cumsum);

--- a/src/caffe/layers/detection_output_layer.cu
+++ b/src/caffe/layers/detection_output_layer.cu
@@ -45,7 +45,6 @@ void DetectionOutputLayer<Dtype>::Forward_gpu(
   PermuteDataGPU<Dtype>(bottom[1]->count(), bottom[1]->gpu_data(),
       num_classes_, num_priors_, 1, conf_permute_data);
   const Dtype* conf_cpu_data = conf_permute_.cpu_data();
-
   int num_kept = 0;
   vector<map<int, vector<int> > > all_indices;
   for (int i = 0; i < num; ++i) {

--- a/src/caffe/util/bbox_util.cpp
+++ b/src/caffe/util/bbox_util.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <csignal>
+#include <chrono>
 #include <ctime>
 #include <functional>
 #include <map>
@@ -2133,7 +2134,7 @@ vector<cv::Scalar> GetColors(const int n) {
   return colors;
 }
 
-static clock_t start_clock = clock();
+static std::chrono::time_point<std::chrono::system_clock> start_time = std::chrono::system_clock::now();
 static cv::VideoWriter cap_out;
 
 template <typename Dtype>
@@ -2149,8 +2150,10 @@ void VisualizeBBox(const vector<cv::Mat>& images, const Blob<Dtype>* detections,
     return;
   }
   // Comute FPS.
-  float fps = num_img / (static_cast<double>(clock() - start_clock) /
-          CLOCKS_PER_SEC);
+  std::chrono::time_point<std::chrono::system_clock> end_time = std::chrono::system_clock::now();
+
+  std::chrono::duration<double> elapsed_seconds = end_time -start_time;
+  float fps = num_img / elapsed_seconds.count();
 
   const Dtype* detections_data = detections->cpu_data();
   const int width = images[0].cols;
@@ -2232,7 +2235,7 @@ void VisualizeBBox(const vector<cv::Mat>& images, const Blob<Dtype>* detections,
       raise(SIGINT);
     }
   }
-  start_clock = clock();
+  start_time = std::chrono::system_clock::now();
 }
 
 template

--- a/src/caffe/util/bbox_util.cpp
+++ b/src/caffe/util/bbox_util.cpp
@@ -1767,31 +1767,31 @@ void GetMaxScoreIndex(const vector<float>& scores, const float threshold,
 
 template <typename Dtype>
 void GetMaxScoreIndex(const Dtype* scores, const int num, const float threshold,
-      const int top_k, vector<pair<Dtype, int> >* score_index_vec) {
+      const int top_k, vector<pair<Dtype, int> >& score_index_vec) {
   // Generate index score pairs.
   for (int i = 0; i < num; ++i) {
     if (scores[i] > threshold) {
-      score_index_vec->push_back(std::make_pair(scores[i], i));
+      score_index_vec.push_back(std::make_pair(scores[i], i));
     }
   }
-
-  // Sort the score pair according to the scores in descending order
-  std::sort(score_index_vec->begin(), score_index_vec->end(),
+  if (score_index_vec.size() > top_k && top_k > -1) {
+    std::partial_sort(score_index_vec.begin(), score_index_vec.begin() + top_k,
+                        score_index_vec.end(), SortScorePairDescend<int>);
+    score_index_vec.resize(top_k);
+  } else {
+    // Sort the score pair according to the scores in descending order
+    std::sort(score_index_vec.begin(), score_index_vec.end(),
             SortScorePairDescend<int>);
-
-  // Keep top_k scores if needed.
-  if (top_k > -1 && top_k < score_index_vec->size()) {
-    score_index_vec->resize(top_k);
   }
 }
 
 template
 void GetMaxScoreIndex(const float* scores, const int num, const float threshold,
-      const int top_k, vector<pair<float, int> >* score_index_vec);
+      const int top_k, vector<pair<float, int> >& score_index_vec);
 template
 void GetMaxScoreIndex(const double* scores, const int num,
       const float threshold, const int top_k,
-      vector<pair<double, int> >* score_index_vec);
+      vector<pair<double, int> >& score_index_vec);
 
 void ApplyNMS(const vector<NormalizedBBox>& bboxes, const vector<float>& scores,
       const float threshold, const int top_k, const bool reuse_overlaps,
@@ -1944,20 +1944,18 @@ void ApplyNMSFast(const vector<NormalizedBBox>& bboxes,
 template <typename Dtype>
 void ApplyNMSFast(const Dtype* bboxes, const Dtype* scores, const int num,
       const float score_threshold, const float nms_threshold,
-      const float eta, const int top_k, vector<int>* indices) {
+      const float eta, const int top_k, vector<int>& indices) {
   // Get top_k scores (with corresponding indices).
   vector<pair<Dtype, int> > score_index_vec;
-  GetMaxScoreIndex(scores, num, score_threshold, top_k, &score_index_vec);
-
-  // Do nms.
+  score_index_vec.reserve(num);
+  GetMaxScoreIndex(scores, num, score_threshold, top_k, score_index_vec);
   float adaptive_threshold = nms_threshold;
-  indices->clear();
-  while (score_index_vec.size() != 0) {
-    const int idx = score_index_vec.front().second;
+  for (auto i =0; i < score_index_vec.size(); ++i) {
+    const int idx = score_index_vec[i].second;
     bool keep = true;
-    for (int k = 0; k < indices->size(); ++k) {
+    for (int k = 0; k < indices.size(); ++k) {
       if (keep) {
-        const int kept_idx = (*indices)[k];
+        const int kept_idx = indices[k];
         float overlap = JaccardOverlap(bboxes + idx * 4, bboxes + kept_idx * 4);
         keep = overlap <= adaptive_threshold;
       } else {
@@ -1965,9 +1963,8 @@ void ApplyNMSFast(const Dtype* bboxes, const Dtype* scores, const int num,
       }
     }
     if (keep) {
-      indices->push_back(idx);
+      indices.push_back(idx);
     }
-    score_index_vec.erase(score_index_vec.begin());
     if (keep && eta < 1 && adaptive_threshold > 0.5) {
       adaptive_threshold *= eta;
     }
@@ -1977,11 +1974,11 @@ void ApplyNMSFast(const Dtype* bboxes, const Dtype* scores, const int num,
 template
 void ApplyNMSFast(const float* bboxes, const float* scores, const int num,
       const float score_threshold, const float nms_threshold,
-      const float eta, const int top_k, vector<int>* indices);
+      const float eta, const int top_k, vector<int>& indices);
 template
 void ApplyNMSFast(const double* bboxes, const double* scores, const int num,
       const float score_threshold, const float nms_threshold,
-      const float eta, const int top_k, vector<int>* indices);
+      const float eta, const int top_k, vector<int>& indices);
 
 void CumSum(const vector<pair<float, int> >& pairs, vector<int>* cumsum) {
   // Sort the pairs based on first item of the pair.


### PR DESCRIPTION
Hi @gongzg
It is the initial optimized version of detection_output layer. 
On examples benchmark.sh, detection layer's improved from 9.5ms to 4.2 ms.
To enable omp need to added -DUSE_OPENMP=ON on CMake parameters.