### PR TITLE
Fix "nan" value bug for matvec_mul.cl

### DIFF
--- a/src/caffe/greentea/cl_kernels.cpp
+++ b/src/caffe/greentea/cl_kernels.cpp
@@ -5423,8 +5423,14 @@ static std::vector<std::vector<std::string>> cl_kernels{
 "if(lid < stride)",    // NOLINT
 "work[lid] += work[lid+stride];",    // NOLINT
 "}",    // NOLINT
-"if(lid == 0)",    // NOLINT
+"",    // NOLINT
+"if(lid == 0) {",    // NOLINT
+"if(beta == (Dtype)0)",    // NOLINT
+"result[row_gid] = alpha * work[0];",    // NOLINT
+"else",    // NOLINT
 "result[row_gid] = alpha * work[0] + beta * result[row_gid];",    // NOLINT
+"}",    // NOLINT
+"",    // NOLINT
 "}",    // NOLINT
 "",    // NOLINT
 "/* This kernel used for the trailing rows when row_of_A %4 !=0 */",    // NOLINT
@@ -5484,9 +5490,12 @@ static std::vector<std::vector<std::string>> cl_kernels{
 "}",    // NOLINT
 "",    // NOLINT
 "if(lid == 0) {",    // NOLINT
+"if(beta == (Dtype)0) {",    // NOLINT
+"result[row_gid+row_offset] = alpha * work[0];",    // NOLINT
+"} else {",    // NOLINT
 "result[row_gid+row_offset] *= beta;",    // NOLINT
 "result[row_gid+row_offset] += alpha * work[0];",    // NOLINT
-"//result[row_gid+row_offset] = alpha * work[0] + beta * result[row_gid+row_offset];",    // NOLINT
+"}",    // NOLINT
 "}",    // NOLINT
 "}",    // NOLINT
 ""},   // NOLINT

--- a/src/caffe/greentea/cl_kernels/matvec_mul.cl
+++ b/src/caffe/greentea/cl_kernels/matvec_mul.cl
@@ -75,8 +75,14 @@ __kernel void TEMPLATE(matvec_mul4,Dtype)(
       if(lid < stride)
         work[lid] += work[lid+stride];
   }
-  if(lid == 0)
-    result[row_gid] = alpha * work[0] + beta * result[row_gid];
+
+  if(lid == 0) {
+    if(beta == (Dtype)0)
+      result[row_gid] = alpha * work[0];
+    else
+      result[row_gid] = alpha * work[0] + beta * result[row_gid];
+  }
+
 }
 
 /* This kernel used for the trailing rows when row_of_A %4 !=0 */
@@ -136,8 +142,11 @@ __kernel void TEMPLATE(matvec_mul1,Dtype)(
   }
 
   if(lid == 0) {
-    result[row_gid+row_offset] *= beta;
-    result[row_gid+row_offset] += alpha * work[0];
-    //result[row_gid+row_offset] = alpha * work[0] + beta * result[row_gid+row_offset];
+    if(beta == (Dtype)0) {
+      result[row_gid+row_offset] = alpha * work[0];
+    } else {
+      result[row_gid+row_offset] *= beta;
+      result[row_gid+row_offset] += alpha * work[0];
+    }
   }
 }


### PR DESCRIPTION
If the output buffer didn't initialized, the kernel code:
"result[row_gid] = alpha * work[0] + beta * result[row_gid];".
will make "result[row_gid]" to be "nan" no matter whether "beta"
is zero.
@gongzg 
