### PR TITLE
Minor compiling issue fixed

### DIFF
--- a/include/3rdparty/half/half.hpp
+++ b/include/3rdparty/half/half.hpp
@@ -271,7 +271,7 @@ namespace half_float
 	/// ~~~~
 	namespace literal
 	{
-		half operator""_h(long double);
+		half operator "" _h(long double);
 	}
 #endif
 
@@ -1082,7 +1082,7 @@ namespace half_float
 		friend struct std::hash<half>;
 	#endif
 	#if HALF_ENABLE_CPP11_USER_LITERALS
-		friend half literal::operator""_h(long double);
+		friend half literal::operator "" _h(long double);
 	#endif
 
 	public:
@@ -1196,7 +1196,7 @@ namespace half_float
 		/// to rather involved conversions.
 		/// \param value literal value
 		/// \return half with given value (if representable)
-		inline half operator""_h(long double value) { return half(detail::binary, detail::float2half<half::round_style>(value)); }
+		inline half operator "" _h(long double value) { return half(detail::binary, detail::float2half<half::round_style>(value)); }
 	}
 #endif
 

--- a/src/caffe/layers/malis_loss_layer.cpp
+++ b/src/caffe/layers/malis_loss_layer.cpp
@@ -390,9 +390,10 @@ void MalisLossLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
     }
   }
 
-  Dtype loss = 0;
-
+  double loss = 0;
+#ifdef _OPENMP
 #pragma omp parallel for reduction(+:loss)
+#endif
   for (int_tp batch = 0; batch < bottom[0]->shape()[0]; ++batch) {
     Dtype loss_out = 0;
     Dtype classerr_out = 0;


### PR DESCRIPTION
This patch include compiling failure fixed for some conditions.
1. Fixed an omp compiling error when setting USE_OPENMP=ON.
2. Fixed an half.hpp compiling error when using GCC4.8 for compiling.