### PR TITLE
DepthWise Conv Enabled

### DIFF
--- a/include/caffe/layers/conv_spatial_layer.hpp
+++ b/include/caffe/layers/conv_spatial_layer.hpp
@@ -13,7 +13,7 @@
 #include "caffe/layers/base_conv_layer.hpp"
 
 namespace caffe {
-enum class ConvType: int_tp {IDLF = 2, WINOGRAD = 3, BASIC = 4, GEMM_LIKE = 5};
+enum class ConvType: int_tp {IDLF = 2, WINOGRAD = 3, BASIC = 4, GEMM_LIKE = 5, DWCONV = 6};
 template<typename Dtype>
 class ConvolutionLayerSpatial : public BaseConvolutionLayer<Dtype> {
  public:
@@ -158,6 +158,11 @@ class ConvolutionLayerSpatial : public BaseConvolutionLayer<Dtype> {
                                    int_tp blockWidth,
                                    int_tp blockHeight,
                                    int_tp blockDepth);
+  virtual bool create_dw_conv_kernel(const vector<Blob<Dtype>*>& bottom,
+                                   const vector<Blob<Dtype>*>& top,
+                                   int_tp blockWidth,
+                                   int_tp blockHeight,
+                                   int_tp blockDepth);
 
   virtual cl_int convolve(const vector<Blob<Dtype>*>& bottom,
                           const vector<Blob<Dtype>*>& top, int_tp index,
@@ -179,7 +184,7 @@ class ConvolutionLayerSpatial : public BaseConvolutionLayer<Dtype> {
                               bool interleave = false);
   virtual void winogradWeights();
   virtual void generate_key();
-  virtual std::string generate_specific_key(int_tp type, int_tp blockWidth,
+  virtual std::string generate_specific_key(ConvType type, int_tp blockWidth,
   int_tp blockHeight,
                                             int_tp blockDepth);
   virtual void calculate_global_size(int_tp batch, int_tp* workItemOutput,
@@ -260,6 +265,7 @@ class ConvolutionLayerSpatial : public BaseConvolutionLayer<Dtype> {
   int_tp N_;
 
   bool tuned_;
+  bool dwconv_;
 
   std::string key_;
   std::string short_key_;

--- a/models/inference_optimize/merged_mobilenet_deploy.prototxt
+++ b/models/inference_optimize/merged_mobilenet_deploy.prototxt
@@ -1,0 +1,725 @@
+name: "MOBILENET"
+layer {
+  name: "data"
+  type: "Input"
+  top: "data"
+  transform_param {
+    scale: 0.0170000009239
+    mirror: false
+    crop_size: 224
+    mean_value: 103.940002441
+    mean_value: 116.779998779
+    mean_value: 123.680000305
+  }
+  input_param {
+    shape {
+      dim: 1
+      dim: 3
+      dim: 224
+      dim: 224
+    }
+  }
+}
+layer {
+  name: "conv1"
+  type: "Convolution"
+  bottom: "data"
+  top: "conv1"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 32
+    bias_term: true
+    pad: 1
+    kernel_size: 3
+    stride: 2
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv2_1/dw"
+  type: "Convolution"
+  bottom: "conv1"
+  top: "conv2_1/dw"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 32
+    bias_term: true
+    pad: 1
+    kernel_size: 3
+    group: 32
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv2_1/sep"
+  type: "Convolution"
+  bottom: "conv2_1/dw"
+  top: "conv2_1/sep"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 64
+    bias_term: true
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv2_2/dw"
+  type: "Convolution"
+  bottom: "conv2_1/sep"
+  top: "conv2_2/dw"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 64
+    bias_term: true
+    pad: 1
+    kernel_size: 3
+    group: 64
+    stride: 2
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv2_2/sep"
+  type: "Convolution"
+  bottom: "conv2_2/dw"
+  top: "conv2_2/sep"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 128
+    bias_term: true
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv3_1/dw"
+  type: "Convolution"
+  bottom: "conv2_2/sep"
+  top: "conv3_1/dw"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 128
+    bias_term: true
+    pad: 1
+    kernel_size: 3
+    group: 128
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv3_1/sep"
+  type: "Convolution"
+  bottom: "conv3_1/dw"
+  top: "conv3_1/sep"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 128
+    bias_term: true
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv3_2/dw"
+  type: "Convolution"
+  bottom: "conv3_1/sep"
+  top: "conv3_2/dw"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 128
+    bias_term: true
+    pad: 1
+    kernel_size: 3
+    group: 128
+    stride: 2
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv3_2/sep"
+  type: "Convolution"
+  bottom: "conv3_2/dw"
+  top: "conv3_2/sep"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 256
+    bias_term: true
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv4_1/dw"
+  type: "Convolution"
+  bottom: "conv3_2/sep"
+  top: "conv4_1/dw"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 256
+    bias_term: true
+    pad: 1
+    kernel_size: 3
+    group: 256
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv4_1/sep"
+  type: "Convolution"
+  bottom: "conv4_1/dw"
+  top: "conv4_1/sep"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 256
+    bias_term: true
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv4_2/dw"
+  type: "Convolution"
+  bottom: "conv4_1/sep"
+  top: "conv4_2/dw"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 256
+    bias_term: true
+    pad: 1
+    kernel_size: 3
+    group: 256
+    stride: 2
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv4_2/sep"
+  type: "Convolution"
+  bottom: "conv4_2/dw"
+  top: "conv4_2/sep"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: true
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv5_1/dw"
+  type: "Convolution"
+  bottom: "conv4_2/sep"
+  top: "conv5_1/dw"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: true
+    pad: 1
+    kernel_size: 3
+    group: 512
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv5_1/sep"
+  type: "Convolution"
+  bottom: "conv5_1/dw"
+  top: "conv5_1/sep"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: true
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv5_2/dw"
+  type: "Convolution"
+  bottom: "conv5_1/sep"
+  top: "conv5_2/dw"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: true
+    pad: 1
+    kernel_size: 3
+    group: 512
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv5_2/sep"
+  type: "Convolution"
+  bottom: "conv5_2/dw"
+  top: "conv5_2/sep"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: true
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv5_3/dw"
+  type: "Convolution"
+  bottom: "conv5_2/sep"
+  top: "conv5_3/dw"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: true
+    pad: 1
+    kernel_size: 3
+    group: 512
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv5_3/sep"
+  type: "Convolution"
+  bottom: "conv5_3/dw"
+  top: "conv5_3/sep"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: true
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv5_4/dw"
+  type: "Convolution"
+  bottom: "conv5_3/sep"
+  top: "conv5_4/dw"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: true
+    pad: 1
+    kernel_size: 3
+    group: 512
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv5_4/sep"
+  type: "Convolution"
+  bottom: "conv5_4/dw"
+  top: "conv5_4/sep"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: true
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv5_5/dw"
+  type: "Convolution"
+  bottom: "conv5_4/sep"
+  top: "conv5_5/dw"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: true
+    pad: 1
+    kernel_size: 3
+    group: 512
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv5_5/sep"
+  type: "Convolution"
+  bottom: "conv5_5/dw"
+  top: "conv5_5/sep"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: true
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv5_6/dw"
+  type: "Convolution"
+  bottom: "conv5_5/sep"
+  top: "conv5_6/dw"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: true
+    pad: 1
+    kernel_size: 3
+    group: 512
+    stride: 2
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv5_6/sep"
+  type: "Convolution"
+  bottom: "conv5_6/dw"
+  top: "conv5_6/sep"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 1024
+    bias_term: true
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv6/dw"
+  type: "Convolution"
+  bottom: "conv5_6/sep"
+  top: "conv6/dw"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 1024
+    bias_term: true
+    pad: 1
+    kernel_size: 3
+    group: 1024
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "conv6/sep"
+  type: "Convolution"
+  bottom: "conv6/dw"
+  top: "conv6/sep"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  convolution_param {
+    num_output: 1024
+    bias_term: true
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+    fuse_type: FUSED_CONV_RELU
+    relu_param {
+      negative_slope: 0.0
+    }
+  }
+}
+layer {
+  name: "pool6"
+  type: "Pooling"
+  bottom: "conv6/sep"
+  top: "pool6"
+  pooling_param {
+    pool: AVE
+    global_pooling: true
+  }
+}
+layer {
+  name: "fc7"
+  type: "Convolution"
+  bottom: "pool6"
+  top: "fc7"
+  param {
+    lr_mult: 1.0
+    decay_mult: 1.0
+  }
+  param {
+    lr_mult: 2.0
+    decay_mult: 0.0
+  }
+  convolution_param {
+    num_output: 1000
+    kernel_size: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0.0
+    }
+    fuse_type: UNFUSED
+  }
+}
+layer {
+  name: "prob"
+  type: "Softmax"
+  bottom: "fc7"
+  top: "prob"
+}

--- a/models/mobilenet/mobilenet_deploy.prototxt
+++ b/models/mobilenet/mobilenet_deploy.prototxt
@@ -1,0 +1,1673 @@
+name: "MOBILENET"
+layer {
+  name: "data"
+  type: "Input"
+  top: "data"
+  input_param { shape: { dim: 1 dim: 3 dim: 224 dim: 224 } }
+  transform_param {
+    scale: 0.017
+    mirror: false
+    crop_size: 224
+    mean_value: [103.94,116.78,123.68]
+  }
+}
+layer {
+  name: "conv1"
+  type: "Convolution"
+  bottom: "data"
+  top: "conv1"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 32
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    stride: 2
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv1/bn"
+  type: "BatchNorm"
+  bottom: "conv1"
+  top: "conv1"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv1/scale"
+  type: "Scale"
+  bottom: "conv1"
+  top: "conv1"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu1"
+  type: "ReLU"
+  bottom: "conv1"
+  top: "conv1"
+}
+layer {
+  name: "conv2_1/dw"
+  type: "Convolution"
+  bottom: "conv1"
+  top: "conv2_1/dw"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 32
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    group: 32
+    #engine: CAFFE
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv2_1/dw/bn"
+  type: "BatchNorm"
+  bottom: "conv2_1/dw"
+  top: "conv2_1/dw"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv2_1/dw/scale"
+  type: "Scale"
+  bottom: "conv2_1/dw"
+  top: "conv2_1/dw"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu2_1/dw"
+  type: "ReLU"
+  bottom: "conv2_1/dw"
+  top: "conv2_1/dw"
+}
+layer {
+  name: "conv2_1/sep"
+  type: "Convolution"
+  bottom: "conv2_1/dw"
+  top: "conv2_1/sep"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 64
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv2_1/sep/bn"
+  type: "BatchNorm"
+  bottom: "conv2_1/sep"
+  top: "conv2_1/sep"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv2_1/sep/scale"
+  type: "Scale"
+  bottom: "conv2_1/sep"
+  top: "conv2_1/sep"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu2_1/sep"
+  type: "ReLU"
+  bottom: "conv2_1/sep"
+  top: "conv2_1/sep"
+}
+layer {
+  name: "conv2_2/dw"
+  type: "Convolution"
+  bottom: "conv2_1/sep"
+  top: "conv2_2/dw"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 64
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    group: 64
+    #engine: CAFFE
+    stride: 2
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv2_2/dw/bn"
+  type: "BatchNorm"
+  bottom: "conv2_2/dw"
+  top: "conv2_2/dw"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv2_2/dw/scale"
+  type: "Scale"
+  bottom: "conv2_2/dw"
+  top: "conv2_2/dw"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu2_2/dw"
+  type: "ReLU"
+  bottom: "conv2_2/dw"
+  top: "conv2_2/dw"
+}
+layer {
+  name: "conv2_2/sep"
+  type: "Convolution"
+  bottom: "conv2_2/dw"
+  top: "conv2_2/sep"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 128
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv2_2/sep/bn"
+  type: "BatchNorm"
+  bottom: "conv2_2/sep"
+  top: "conv2_2/sep"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv2_2/sep/scale"
+  type: "Scale"
+  bottom: "conv2_2/sep"
+  top: "conv2_2/sep"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu2_2/sep"
+  type: "ReLU"
+  bottom: "conv2_2/sep"
+  top: "conv2_2/sep"
+}
+layer {
+  name: "conv3_1/dw"
+  type: "Convolution"
+  bottom: "conv2_2/sep"
+  top: "conv3_1/dw"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 128
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    group: 128
+    #engine: CAFFE
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv3_1/dw/bn"
+  type: "BatchNorm"
+  bottom: "conv3_1/dw"
+  top: "conv3_1/dw"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv3_1/dw/scale"
+  type: "Scale"
+  bottom: "conv3_1/dw"
+  top: "conv3_1/dw"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu3_1/dw"
+  type: "ReLU"
+  bottom: "conv3_1/dw"
+  top: "conv3_1/dw"
+}
+layer {
+  name: "conv3_1/sep"
+  type: "Convolution"
+  bottom: "conv3_1/dw"
+  top: "conv3_1/sep"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 128
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv3_1/sep/bn"
+  type: "BatchNorm"
+  bottom: "conv3_1/sep"
+  top: "conv3_1/sep"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv3_1/sep/scale"
+  type: "Scale"
+  bottom: "conv3_1/sep"
+  top: "conv3_1/sep"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu3_1/sep"
+  type: "ReLU"
+  bottom: "conv3_1/sep"
+  top: "conv3_1/sep"
+}
+layer {
+  name: "conv3_2/dw"
+  type: "Convolution"
+  bottom: "conv3_1/sep"
+  top: "conv3_2/dw"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 128
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    group: 128
+    #engine: CAFFE
+    stride: 2
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv3_2/dw/bn"
+  type: "BatchNorm"
+  bottom: "conv3_2/dw"
+  top: "conv3_2/dw"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv3_2/dw/scale"
+  type: "Scale"
+  bottom: "conv3_2/dw"
+  top: "conv3_2/dw"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu3_2/dw"
+  type: "ReLU"
+  bottom: "conv3_2/dw"
+  top: "conv3_2/dw"
+}
+layer {
+  name: "conv3_2/sep"
+  type: "Convolution"
+  bottom: "conv3_2/dw"
+  top: "conv3_2/sep"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv3_2/sep/bn"
+  type: "BatchNorm"
+  bottom: "conv3_2/sep"
+  top: "conv3_2/sep"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv3_2/sep/scale"
+  type: "Scale"
+  bottom: "conv3_2/sep"
+  top: "conv3_2/sep"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu3_2/sep"
+  type: "ReLU"
+  bottom: "conv3_2/sep"
+  top: "conv3_2/sep"
+}
+layer {
+  name: "conv4_1/dw"
+  type: "Convolution"
+  bottom: "conv3_2/sep"
+  top: "conv4_1/dw"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    group: 256
+    #engine: CAFFE
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv4_1/dw/bn"
+  type: "BatchNorm"
+  bottom: "conv4_1/dw"
+  top: "conv4_1/dw"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv4_1/dw/scale"
+  type: "Scale"
+  bottom: "conv4_1/dw"
+  top: "conv4_1/dw"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu4_1/dw"
+  type: "ReLU"
+  bottom: "conv4_1/dw"
+  top: "conv4_1/dw"
+}
+layer {
+  name: "conv4_1/sep"
+  type: "Convolution"
+  bottom: "conv4_1/dw"
+  top: "conv4_1/sep"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv4_1/sep/bn"
+  type: "BatchNorm"
+  bottom: "conv4_1/sep"
+  top: "conv4_1/sep"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv4_1/sep/scale"
+  type: "Scale"
+  bottom: "conv4_1/sep"
+  top: "conv4_1/sep"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu4_1/sep"
+  type: "ReLU"
+  bottom: "conv4_1/sep"
+  top: "conv4_1/sep"
+}
+layer {
+  name: "conv4_2/dw"
+  type: "Convolution"
+  bottom: "conv4_1/sep"
+  top: "conv4_2/dw"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 256
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    group: 256
+    #engine: CAFFE
+    stride: 2
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv4_2/dw/bn"
+  type: "BatchNorm"
+  bottom: "conv4_2/dw"
+  top: "conv4_2/dw"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv4_2/dw/scale"
+  type: "Scale"
+  bottom: "conv4_2/dw"
+  top: "conv4_2/dw"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu4_2/dw"
+  type: "ReLU"
+  bottom: "conv4_2/dw"
+  top: "conv4_2/dw"
+}
+layer {
+  name: "conv4_2/sep"
+  type: "Convolution"
+  bottom: "conv4_2/dw"
+  top: "conv4_2/sep"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv4_2/sep/bn"
+  type: "BatchNorm"
+  bottom: "conv4_2/sep"
+  top: "conv4_2/sep"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv4_2/sep/scale"
+  type: "Scale"
+  bottom: "conv4_2/sep"
+  top: "conv4_2/sep"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu4_2/sep"
+  type: "ReLU"
+  bottom: "conv4_2/sep"
+  top: "conv4_2/sep"
+}
+layer {
+  name: "conv5_1/dw"
+  type: "Convolution"
+  bottom: "conv4_2/sep"
+  top: "conv5_1/dw"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    group: 512
+    #engine: CAFFE
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv5_1/dw/bn"
+  type: "BatchNorm"
+  bottom: "conv5_1/dw"
+  top: "conv5_1/dw"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv5_1/dw/scale"
+  type: "Scale"
+  bottom: "conv5_1/dw"
+  top: "conv5_1/dw"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu5_1/dw"
+  type: "ReLU"
+  bottom: "conv5_1/dw"
+  top: "conv5_1/dw"
+}
+layer {
+  name: "conv5_1/sep"
+  type: "Convolution"
+  bottom: "conv5_1/dw"
+  top: "conv5_1/sep"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv5_1/sep/bn"
+  type: "BatchNorm"
+  bottom: "conv5_1/sep"
+  top: "conv5_1/sep"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv5_1/sep/scale"
+  type: "Scale"
+  bottom: "conv5_1/sep"
+  top: "conv5_1/sep"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu5_1/sep"
+  type: "ReLU"
+  bottom: "conv5_1/sep"
+  top: "conv5_1/sep"
+}
+layer {
+  name: "conv5_2/dw"
+  type: "Convolution"
+  bottom: "conv5_1/sep"
+  top: "conv5_2/dw"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    group: 512
+    #engine: CAFFE
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv5_2/dw/bn"
+  type: "BatchNorm"
+  bottom: "conv5_2/dw"
+  top: "conv5_2/dw"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv5_2/dw/scale"
+  type: "Scale"
+  bottom: "conv5_2/dw"
+  top: "conv5_2/dw"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu5_2/dw"
+  type: "ReLU"
+  bottom: "conv5_2/dw"
+  top: "conv5_2/dw"
+}
+layer {
+  name: "conv5_2/sep"
+  type: "Convolution"
+  bottom: "conv5_2/dw"
+  top: "conv5_2/sep"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv5_2/sep/bn"
+  type: "BatchNorm"
+  bottom: "conv5_2/sep"
+  top: "conv5_2/sep"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv5_2/sep/scale"
+  type: "Scale"
+  bottom: "conv5_2/sep"
+  top: "conv5_2/sep"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu5_2/sep"
+  type: "ReLU"
+  bottom: "conv5_2/sep"
+  top: "conv5_2/sep"
+}
+layer {
+  name: "conv5_3/dw"
+  type: "Convolution"
+  bottom: "conv5_2/sep"
+  top: "conv5_3/dw"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    group: 512
+    #engine: CAFFE
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv5_3/dw/bn"
+  type: "BatchNorm"
+  bottom: "conv5_3/dw"
+  top: "conv5_3/dw"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv5_3/dw/scale"
+  type: "Scale"
+  bottom: "conv5_3/dw"
+  top: "conv5_3/dw"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu5_3/dw"
+  type: "ReLU"
+  bottom: "conv5_3/dw"
+  top: "conv5_3/dw"
+}
+layer {
+  name: "conv5_3/sep"
+  type: "Convolution"
+  bottom: "conv5_3/dw"
+  top: "conv5_3/sep"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv5_3/sep/bn"
+  type: "BatchNorm"
+  bottom: "conv5_3/sep"
+  top: "conv5_3/sep"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv5_3/sep/scale"
+  type: "Scale"
+  bottom: "conv5_3/sep"
+  top: "conv5_3/sep"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu5_3/sep"
+  type: "ReLU"
+  bottom: "conv5_3/sep"
+  top: "conv5_3/sep"
+}
+layer {
+  name: "conv5_4/dw"
+  type: "Convolution"
+  bottom: "conv5_3/sep"
+  top: "conv5_4/dw"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    group: 512
+    #engine: CAFFE
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv5_4/dw/bn"
+  type: "BatchNorm"
+  bottom: "conv5_4/dw"
+  top: "conv5_4/dw"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv5_4/dw/scale"
+  type: "Scale"
+  bottom: "conv5_4/dw"
+  top: "conv5_4/dw"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu5_4/dw"
+  type: "ReLU"
+  bottom: "conv5_4/dw"
+  top: "conv5_4/dw"
+}
+layer {
+  name: "conv5_4/sep"
+  type: "Convolution"
+  bottom: "conv5_4/dw"
+  top: "conv5_4/sep"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv5_4/sep/bn"
+  type: "BatchNorm"
+  bottom: "conv5_4/sep"
+  top: "conv5_4/sep"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv5_4/sep/scale"
+  type: "Scale"
+  bottom: "conv5_4/sep"
+  top: "conv5_4/sep"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu5_4/sep"
+  type: "ReLU"
+  bottom: "conv5_4/sep"
+  top: "conv5_4/sep"
+}
+layer {
+  name: "conv5_5/dw"
+  type: "Convolution"
+  bottom: "conv5_4/sep"
+  top: "conv5_5/dw"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    group: 512
+    #engine: CAFFE
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv5_5/dw/bn"
+  type: "BatchNorm"
+  bottom: "conv5_5/dw"
+  top: "conv5_5/dw"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv5_5/dw/scale"
+  type: "Scale"
+  bottom: "conv5_5/dw"
+  top: "conv5_5/dw"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu5_5/dw"
+  type: "ReLU"
+  bottom: "conv5_5/dw"
+  top: "conv5_5/dw"
+}
+layer {
+  name: "conv5_5/sep"
+  type: "Convolution"
+  bottom: "conv5_5/dw"
+  top: "conv5_5/sep"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv5_5/sep/bn"
+  type: "BatchNorm"
+  bottom: "conv5_5/sep"
+  top: "conv5_5/sep"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv5_5/sep/scale"
+  type: "Scale"
+  bottom: "conv5_5/sep"
+  top: "conv5_5/sep"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu5_5/sep"
+  type: "ReLU"
+  bottom: "conv5_5/sep"
+  top: "conv5_5/sep"
+}
+layer {
+  name: "conv5_6/dw"
+  type: "Convolution"
+  bottom: "conv5_5/sep"
+  top: "conv5_6/dw"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 512
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    group: 512
+    #engine: CAFFE
+    stride: 2
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv5_6/dw/bn"
+  type: "BatchNorm"
+  bottom: "conv5_6/dw"
+  top: "conv5_6/dw"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv5_6/dw/scale"
+  type: "Scale"
+  bottom: "conv5_6/dw"
+  top: "conv5_6/dw"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu5_6/dw"
+  type: "ReLU"
+  bottom: "conv5_6/dw"
+  top: "conv5_6/dw"
+}
+layer {
+  name: "conv5_6/sep"
+  type: "Convolution"
+  bottom: "conv5_6/dw"
+  top: "conv5_6/sep"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 1024
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv5_6/sep/bn"
+  type: "BatchNorm"
+  bottom: "conv5_6/sep"
+  top: "conv5_6/sep"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv5_6/sep/scale"
+  type: "Scale"
+  bottom: "conv5_6/sep"
+  top: "conv5_6/sep"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu5_6/sep"
+  type: "ReLU"
+  bottom: "conv5_6/sep"
+  top: "conv5_6/sep"
+}
+layer {
+  name: "conv6/dw"
+  type: "Convolution"
+  bottom: "conv5_6/sep"
+  top: "conv6/dw"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 1024
+    bias_term: false
+    pad: 1
+    kernel_size: 3
+    group: 1024
+    #engine: CAFFE
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv6/dw/bn"
+  type: "BatchNorm"
+  bottom: "conv6/dw"
+  top: "conv6/dw"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv6/dw/scale"
+  type: "Scale"
+  bottom: "conv6/dw"
+  top: "conv6/dw"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu6/dw"
+  type: "ReLU"
+  bottom: "conv6/dw"
+  top: "conv6/dw"
+}
+layer {
+  name: "conv6/sep"
+  type: "Convolution"
+  bottom: "conv6/dw"
+  top: "conv6/sep"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  convolution_param {
+    num_output: 1024
+    bias_term: false
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "msra"
+    }
+  }
+}
+layer {
+  name: "conv6/sep/bn"
+  type: "BatchNorm"
+  bottom: "conv6/sep"
+  top: "conv6/sep"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+}
+layer {
+  name: "conv6/sep/scale"
+  type: "Scale"
+  bottom: "conv6/sep"
+  top: "conv6/sep"
+  scale_param {
+    filler {
+      value: 1
+    }
+    bias_term: true
+    bias_filler {
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu6/sep"
+  type: "ReLU"
+  bottom: "conv6/sep"
+  top: "conv6/sep"
+}
+layer {
+  name: "pool6"
+  type: "Pooling"
+  bottom: "conv6/sep"
+  top: "pool6"
+  pooling_param {
+    pool: AVE
+    global_pooling: true
+  }
+}
+layer {
+  name: "fc7"
+  type: "Convolution"
+  bottom: "pool6"
+  top: "fc7"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 1000
+    kernel_size: 1
+    weight_filler {
+      type: "msra"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "prob"
+  type: "Softmax"
+  bottom: "fc7"
+  top: "prob"
+}

--- a/src/caffe/greentea/cl_kernels.cpp
+++ b/src/caffe/greentea/cl_kernels.cpp
@@ -2634,7 +2634,11 @@ static std::vector<std::vector<std::string>> cl_kernels{
 "if ((ALIGNED_NUM_FILTERS == TOTAL_NUM_FILTERS || fm < TOTAL_NUM_FILTERS)) {",    // NOLINT
 "uint_tp out_addr = fm * output_width * output_height;",    // NOLINT
 "out_addr += or * output_width + oc;",    // NOLINT
+"#if APPLY_BIAS",    // NOLINT
 "Dtype bias = biases[(fm % ALIGNED_NUM_FILTERS)];",    // NOLINT
+"#else",    // NOLINT
+"Dtype bias = 0.",    // NOLINT
+"#endif",    // NOLINT
 "/*",    // NOLINT
 "A^T = {1, 1, 1, 1, 1, 0,",    // NOLINT
 "0, 1, -1,2,-2,0,",    // NOLINT

--- a/src/caffe/greentea/cl_kernels.cpp
+++ b/src/caffe/greentea/cl_kernels.cpp
@@ -804,8 +804,7 @@ static std::vector<std::vector<std::string>> cl_kernels{
 "image_dataPtrFloat += imageSize - input_width*KERNEL_H*DILATION_Y;",    // NOLINT
 "}",    // NOLINT
 "",    // NOLINT
-"if(APPLY_BIAS == 1)",    // NOLINT
-"{",    // NOLINT
+"#if APPLY_BIAS",    // NOLINT
 "for(int_tp kern = 0; kern < ZPAR; kern++)",    // NOLINT
 "{",    // NOLINT
 "if(kernelNum+kern < OUTPUT_Z)",    // NOLINT
@@ -814,9 +813,7 @@ static std::vector<std::vector<std::string>> cl_kernels{
 "ACTIVATION_FUNCTION(convolved_image, offset, sum[kern] + bias[biasIndex +kern]);",    // NOLINT
 "}",    // NOLINT
 "}",    // NOLINT
-"}",    // NOLINT
-"else",    // NOLINT
-"{",    // NOLINT
+"#else",    // NOLINT
 "for(int_tp kern = 0; kern < ZPAR; kern++)",    // NOLINT
 "{",    // NOLINT
 "if(kernelNum+kern < OUTPUT_Z)",    // NOLINT
@@ -825,10 +822,65 @@ static std::vector<std::vector<std::string>> cl_kernels{
 "ACTIVATION_FUNCTION(convolved_image, offset, sum[kern]);",    // NOLINT
 "}",    // NOLINT
 "}",    // NOLINT
-"}",    // NOLINT
+"#endif",    // NOLINT
 "}",    // NOLINT
 "}",    // NOLINT
 "",    // NOLINT
+"#endif",    // NOLINT
+"",    // NOLINT
+"#ifdef DWCONV",    // NOLINT
+"__kernel void DWCONV(",    // NOLINT
+"ELTWISE_DATA_ARG",    // NOLINT
+"NEGATIVE_SLOPE_ARG",    // NOLINT
+"__global Dtype* image_data,",    // NOLINT
+"__global Dtype* kernel_data,",    // NOLINT
+"__global Dtype* bias,",    // NOLINT
+"__global Dtype* convolved_image,",    // NOLINT
+"const ushort input_width,",    // NOLINT
+"const ushort input_height,",    // NOLINT
+"const ushort output_width,",    // NOLINT
+"const ushort output_height) {",    // NOLINT
+"",    // NOLINT
+"const int_tp outputX = get_global_id(0);",    // NOLINT
+"const int_tp outputY = get_global_id(1);",    // NOLINT
+"const int_tp outputZ = get_global_id(2);",    // NOLINT
+"if(outputX < output_width && outputY < output_height)",    // NOLINT
+"{",    // NOLINT
+"Dtype sum = 0.;",    // NOLINT
+"",    // NOLINT
+"const int_tp org_y = outputY * STRIDE_H - PAD_H;",    // NOLINT
+"const int_tp org_x = outputX * STRIDE_W - PAD_W;",    // NOLINT
+"const int_tp currentKernelOffset = KERNELSIZE*(outputZ%CHANNELS);",    // NOLINT
+"const int_tp biasIndex=outputZ%CHANNELS;",    // NOLINT
+"const int_tp local_image_offset = org_y*input_width + org_x;",    // NOLINT
+"const int_tp imageSize = input_width*input_height;",    // NOLINT
+"",    // NOLINT
+"__global Dtype* image_dataPtrFloat = (image_data + (imageSize*outputZ + local_image_offset));",    // NOLINT
+"__global Dtype* kernel_dataPtrFloat = (kernel_data + (currentKernelOffset));",    // NOLINT
+"",    // NOLINT
+"for(int_tp y = 0; y < KERNEL_H; y++)",    // NOLINT
+"{",    // NOLINT
+"for(int_tp x = 0; x < KERNEL_W; x++)",    // NOLINT
+"{",    // NOLINT
+"if(!(org_y + y * DILATION_Y >= 0 && org_y + y * DILATION_Y < input_height && org_x + x * DILATION_X >= 0 && org_x + x * DILATION_X < input_width))",    // NOLINT
+"{",    // NOLINT
+"continue;",    // NOLINT
+"}",    // NOLINT
+"sum += image_dataPtrFloat[x * DILATION_X] * kernel_dataPtrFloat[x];",    // NOLINT
+"}",    // NOLINT
+"image_dataPtrFloat += input_width * DILATION_Y;",    // NOLINT
+"kernel_dataPtrFloat += KERNEL_W;",    // NOLINT
+"}",    // NOLINT
+"",    // NOLINT
+"#if APPLY_BIAS",    // NOLINT
+"int_tp offset = outputZ*output_height*output_width + outputY*output_width + outputX;",    // NOLINT
+"ACTIVATION_FUNCTION(convolved_image, offset, sum + bias[biasIndex]);",    // NOLINT
+"#else",    // NOLINT
+"int_tp offset = outputZ*output_height*output_width + outputY*output_width + outputX;",    // NOLINT
+"ACTIVATION_FUNCTION(convolved_image, offset, sum);",    // NOLINT
+"#endif",    // NOLINT
+"}",    // NOLINT
+"}",    // NOLINT
 "#endif",    // NOLINT
 "",    // NOLINT
 "#if defined(convolve_simd) || defined(Conv_Interleaved)",    // NOLINT

--- a/src/caffe/greentea/cl_kernels/conv_layer_spatial.cl
+++ b/src/caffe/greentea/cl_kernels/conv_layer_spatial.cl
@@ -2055,7 +2055,11 @@ winograd_4x4(
   if ((ALIGNED_NUM_FILTERS == TOTAL_NUM_FILTERS || fm < TOTAL_NUM_FILTERS)) {
     uint_tp out_addr = fm * output_width * output_height;
     out_addr += or * output_width + oc;
+#if APPLY_BIAS
     Dtype bias = biases[(fm % ALIGNED_NUM_FILTERS)];
+#else
+    Dtype bias = 0.
+#endif
       /*
       A^T = {1, 1, 1, 1, 1, 0,
              0, 1, -1,2,-2,0,

--- a/src/caffe/greentea/cl_kernels/conv_layer_spatial.cl
+++ b/src/caffe/greentea/cl_kernels/conv_layer_spatial.cl
@@ -101,31 +101,83 @@ __kernel void CFMultiNoPadding(
       image_dataPtrFloat += imageSize - input_width*KERNEL_H*DILATION_Y;
     }
 
-    if(APPLY_BIAS == 1)
+    #if APPLY_BIAS
+    for(int_tp kern = 0; kern < ZPAR; kern++)
     {
-      for(int_tp kern = 0; kern < ZPAR; kern++)
+      if(kernelNum+kern < OUTPUT_Z)
       {
-        if(kernelNum+kern < OUTPUT_Z)
-        {
-            int_tp offset = convolved_image_offset + (kernelNum+kern)*output_height*output_width + outputY*output_width + outputX;
-            ACTIVATION_FUNCTION(convolved_image, offset, sum[kern] + bias[biasIndex +kern]);
-        }
+        int_tp offset = convolved_image_offset + (kernelNum+kern)*output_height*output_width + outputY*output_width + outputX;
+        ACTIVATION_FUNCTION(convolved_image, offset, sum[kern] + bias[biasIndex +kern]);
       }
     }
-    else
+    #else
+    for(int_tp kern = 0; kern < ZPAR; kern++)
     {
-        for(int_tp kern = 0; kern < ZPAR; kern++)
-        {
-            if(kernelNum+kern < OUTPUT_Z)
-            {
-                int_tp offset = convolved_image_offset + (kernelNum+kern)*output_height*output_width + outputY*output_width + outputX;
-                ACTIVATION_FUNCTION(convolved_image, offset, sum[kern]);
-            }
-        }
+      if(kernelNum+kern < OUTPUT_Z)
+      {
+        int_tp offset = convolved_image_offset + (kernelNum+kern)*output_height*output_width + outputY*output_width + outputX;
+        ACTIVATION_FUNCTION(convolved_image, offset, sum[kern]);
+      }
     }
+    #endif
   }
 }
 
+#endif
+
+#ifdef DWCONV
+__kernel void DWCONV(
+    ELTWISE_DATA_ARG
+    NEGATIVE_SLOPE_ARG
+    __global Dtype* image_data,
+    __global Dtype* kernel_data,
+    __global Dtype* bias,
+    __global Dtype* convolved_image,
+    const ushort input_width,
+    const ushort input_height,
+    const ushort output_width,
+    const ushort output_height) {
+
+  const int_tp outputX = get_global_id(0);
+  const int_tp outputY = get_global_id(1);
+  const int_tp outputZ = get_global_id(2);
+  if(outputX < output_width && outputY < output_height)
+  {
+    Dtype sum = 0.;
+
+    const int_tp org_y = outputY * STRIDE_H - PAD_H;
+    const int_tp org_x = outputX * STRIDE_W - PAD_W;
+    const int_tp currentKernelOffset = KERNELSIZE*(outputZ%CHANNELS);
+    const int_tp biasIndex=outputZ%CHANNELS;
+    const int_tp local_image_offset = org_y*input_width + org_x;
+    const int_tp imageSize = input_width*input_height;
+
+    __global Dtype* image_dataPtrFloat = (image_data + (imageSize*outputZ + local_image_offset));
+    __global Dtype* kernel_dataPtrFloat = (kernel_data + (currentKernelOffset));
+
+    for(int_tp y = 0; y < KERNEL_H; y++)
+    {
+      for(int_tp x = 0; x < KERNEL_W; x++)
+      {
+        if(!(org_y + y * DILATION_Y >= 0 && org_y + y * DILATION_Y < input_height && org_x + x * DILATION_X >= 0 && org_x + x * DILATION_X < input_width))
+        {
+          continue;
+        }
+        sum += image_dataPtrFloat[x * DILATION_X] * kernel_dataPtrFloat[x];
+      }
+      image_dataPtrFloat += input_width * DILATION_Y;
+      kernel_dataPtrFloat += KERNEL_W;
+    }
+
+    #if APPLY_BIAS
+    int_tp offset = outputZ*output_height*output_width + outputY*output_width + outputX;
+    ACTIVATION_FUNCTION(convolved_image, offset, sum + bias[biasIndex]);
+    #else
+    int_tp offset = outputZ*output_height*output_width + outputY*output_width + outputX;
+    ACTIVATION_FUNCTION(convolved_image, offset, sum);
+    #endif
+  }
+}
 #endif
 
 #if defined(convolve_simd) || defined(Conv_Interleaved)

--- a/src/caffe/layers/conv_layer_spatial.cpp
+++ b/src/caffe/layers/conv_layer_spatial.cpp
@@ -1241,6 +1241,7 @@ bool ConvolutionLayerSpatial<Dtype>::create_winograd_conv_kernel(
                 << " -D IS_LARGE_INPUT=" << is_large_input
                 << " -DTOTAL_INPUT_DEPTH_SIZE=" << this->channels_
                 << " -DTOTAL_OUTPUT_DEPTH=" << this->num_output_
+                << " -D APPLY_BIAS=" << this->bias_term_
                 << " -DNUM_FILTERS=" << M_
                 << " -DTILE_X=" << tile_x
                 << " -DTILE_Y=" << tile_y

--- a/src/caffe/layers/conv_layer_spatial.cpp
+++ b/src/caffe/layers/conv_layer_spatial.cpp
@@ -73,6 +73,8 @@ void ConvolutionLayerSpatial<Dtype>::LayerSetUp(
   bias_ = NULL;
   winograd_weights_image_ = NULL;
 
+  dwconv_ = (this->num_output_ == this->channels_ && this->channels_ == this->group_);
+
   if (IsFusedWithEltwiseReLU()) {
     CHECK_EQ(
       this->layer_param().convolution_param().eltwise_param().coeff_size(),
@@ -127,7 +129,6 @@ void ConvolutionLayerSpatial<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
   const int_tp kernel_extent_w = dilation_w_ * (kernel_w_ - 1) + 1;
   output_h_ = (height_ + 2 * pad_h_ - kernel_extent_h) / stride_h_ + 1;
   output_w_ = (width_ + 2 * pad_w_ - kernel_extent_w) / stride_w_ + 1;
-
   // Shape the tops.
   vector<int_tp> top_shape(bottom[0]->shape().begin(),
                            bottom[0]->shape().begin() + this->channel_axis_);
@@ -270,11 +271,11 @@ void ConvolutionLayerSpatial<Dtype>::generate_key() {
 
 template<typename Dtype>
 std::string ConvolutionLayerSpatial<Dtype>::generate_specific_key(
-    int_tp type, int_tp blockWidth, int_tp blockHeight, int_tp blockDepth) {
+    ConvType type, int_tp blockWidth, int_tp blockHeight, int_tp blockDepth) {
   CHECK_EQ((std::is_same<Dtype, double>::value), false);
   std::stringstream keyBuilder;
   keyBuilder << short_key_
-             << "_" << type
+             << "_" << static_cast<int_tp>(type)
              << "_" << blockWidth
              << "_" << blockHeight
              << "_" << blockDepth;
@@ -525,7 +526,7 @@ bool ConvolutionLayerSpatial<Dtype>::create_basic_kernel(
   std::string stringBuilder;
   std::stringstream optionsString;
   std::string kernelDef = "MULTI";
-  std::string kernelUKey = generate_specific_key(4, blockWidth, blockHeight,
+  std::string kernelUKey = generate_specific_key(ConvType::BASIC, blockWidth, blockHeight,
                                                  blockDepth);
   int_tp workItemOutput[3];
   workItemOutput[0] = 1;
@@ -879,6 +880,37 @@ cl_int ConvolutionLayerSpatial<Dtype>::convolve(
     }
     if (err != CL_SUCCESS)
       return err;
+  } else if (config->kernelType == ConvType::DWCONV) {
+
+      cl_uint argIdx = 0;
+      if (IsFusedWithEltwiseReLU())
+        kernel.arg(argIdx++,
+                     WrapHandle((cl_mem) bottom[1]->gpu_data(), &ctx));
+      if (IsFusedWithReLU())
+        kernel.arg(argIdx++, fixup_arg_type(negative_slope_));
+
+      kernel.arg(argIdx++, WrapHandle((cl_mem) bottom_data, &ctx));
+      kernel.arg(argIdx++, WrapHandle((cl_mem) weight, &ctx));
+      kernel.arg(argIdx++, WrapHandle((cl_mem) bias_, &ctx));
+      kernel.arg(argIdx++, WrapHandle((cl_mem) top_data, &ctx));
+      kernel.arg(argIdx++, (uint16_t)width_);
+      kernel.arg(argIdx++, (uint16_t)height_);
+      kernel.arg(argIdx++, (uint16_t)output_w_);
+      kernel.arg(argIdx++, (uint16_t)output_h_);
+
+      size_t globalSize[3];
+      globalSize[0] = output_w_;
+      globalSize[1] = output_h_;
+      globalSize[2] = this->num_output_*this->num_;
+      err = clEnqueueNDRangeKernel(ctx.get_queue().handle().get(),
+                                       kernel.handle().get(), 3,
+                                       NULL,
+                                       globalSize, NULL, 0, NULL,
+                                       NULL);
+
+      if (err != CL_SUCCESS)
+        return err;
+
   } else {
     for (int_tp n = 0; n < numImages; ++n) {
       for (int_tp g = 0; g < this->group_; ++g) {
@@ -1017,8 +1049,7 @@ bool ConvolutionLayerSpatial<Dtype>::verify_result(
                   0xff,
                   (cl_mem)top[index]->mutable_gpu_data(),
                   0);
-  config->executionTime = timed_convolve(bottom, top, index, numImages,
-                                         config);
+  convolve(bottom, top, index, numImages, config);
   // Currently we can't do verification when conv is fused because the results
   // won't match the results of forward_gpu_gemm. Need more work to fix it.
   // FP16 verification may fail due to the natrue accuracy lost between FP16 and FP32.
@@ -1072,7 +1103,7 @@ bool ConvolutionLayerSpatial<Dtype>::create_gemm_like_conv_kernel(
   std::stringstream multFunctionBuilder;
   std::string stringBuilder;
   std::stringstream optionsString;
-  std::string kernelUKey = generate_specific_key(5, blockM, blockK,
+  std::string kernelUKey = generate_specific_key(ConvType::GEMM_LIKE, blockM, blockK,
                                                  blockN);
   int_tp workItemOutput[3] = { blockM, blockK, blockN };
 
@@ -1170,7 +1201,7 @@ bool ConvolutionLayerSpatial<Dtype>::create_winograd_conv_kernel(
     int_tp blockHeight, int_tp simd_size) {
   std::stringstream optionsString;
   const int_tp blockDepth = 1;
-  std::string kernelUKey = generate_specific_key(3, blockWidth, blockHeight,
+  std::string kernelUKey = generate_specific_key(ConvType::WINOGRAD, blockWidth, blockHeight,
                                                  blockDepth);
   int_tp workItemOutput[3] = { blockWidth, blockHeight, simd_size };
   const int_tp num_output_maps = M_;
@@ -1256,7 +1287,79 @@ bool ConvolutionLayerSpatial<Dtype>::create_winograd_conv_kernel(
     ctx.delete_program(kernel_name_);
     return false;
   }
+}
 
+template<typename Dtype>
+bool ConvolutionLayerSpatial<Dtype>::create_dw_conv_kernel(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top,
+    int_tp blockWidth,
+    int_tp blockHeight, int_tp blockDepth) {
+  CHECK_EQ((std::is_same<Dtype, double>::value), false);
+  // Standard spatial setup is done here
+  std::stringstream keyBuilder;
+  std::stringstream multFunctionBuilder;
+  std::string stringBuilder;
+  std::stringstream optionsString;
+  std::string kernelDef = "DWCONV";
+  std::string kernelUKey = generate_specific_key(ConvType::DWCONV, blockWidth, blockHeight,
+                                                 blockDepth);
+  int_tp workItemOutput[3];
+  workItemOutput[0] = 1;
+  workItemOutput[1] = 1;
+  workItemOutput[2] = 1;
+
+  kernel_name_ = "DWCONV_";
+  kernel_name_ += kernelUKey.c_str();
+
+  // Build list of options and defines
+  optionsString.str("");
+  optionsString << "-cl-fast-relaxed-math "
+                << " -D KERNELSIZE=" << kernel_w_ * kernel_h_
+                << " -D KERNEL_W=" << kernel_w_
+                << " -D KERNEL_H=" << kernel_h_
+                << " -D STRIDE_H=" << stride_h_
+                << " -DDILATION_X=" << dilation_w_
+                << " -DDILATION_Y=" << dilation_h_
+                << " -D STRIDE_W=" << stride_w_
+                << " -D PAD_W=" << pad_w_
+                << " -D PAD_H=" << pad_h_
+                << " -D APPLY_BIAS=" << this->bias_term_
+                << " -D OUTPUT_Z=" << this->num_output_*this->num_
+                << " -D CHANNELS=" << this->num_output_
+                << " -D XPAR=" << workItemOutput[0]
+                << " -D YPAR=" << workItemOutput[1]
+                << " -D ZPAR=" << workItemOutput[2]
+                << " -D " << kernelDef.c_str() << " -D DWCONV="
+                << kernel_name_;
+
+  if (IsFusedWithEltwiseReLU()) {
+    optionsString << " -DFUSED_CONV_ELTWISE=1";
+  }
+
+  if (IsFusedWithReLU()) {
+    optionsString << " -DFUSED_CONV_RELU=1";
+  }
+
+  viennacl::ocl::context &ctx = viennacl::ocl::get_context(this->device_->id());
+  if (IsBeignet(&ctx))
+    optionsString << " -D__BEIGNET__";
+  string options = optionsString.str();
+  try {
+    submit_conv_spatial_program<Dtype>(&ctx, kernel_name_, options);
+  } catch (std::exception& e) {
+    dbgPrint(std::cout << "dwconv kernel generation failed" << std::endl);
+    return false;
+  }
+
+  size_t localSize[3] = { 1, 1, 1 };
+  size_t globalSize[3];
+  calculate_global_size(1, workItemOutput, localSize, globalSize);
+
+  kernelQueue.push_back(
+      new kernelConfig(kernel_name_, globalSize, localSize, workItemOutput,
+                       false, false, true, ConvType::DWCONV));
+
+  return true;
 }
 
 template<typename Dtype>
@@ -1270,7 +1373,7 @@ bool ConvolutionLayerSpatial<Dtype>::setup_IDLF(
   std::string stringBuilder;
   std::stringstream optionsString;
   const int_tp blockDepth = 1;
-  std::string kernelUKey = generate_specific_key(2, blockWidth, blockHeight,
+  std::string kernelUKey = generate_specific_key(ConvType::IDLF, blockWidth, blockHeight,
                                                  blockDepth);
   int_tp workItemOutput[3] = { blockWidth, blockHeight, simd_size };
   const int_tp num_output_maps = M_;
@@ -1469,6 +1572,9 @@ void ConvolutionLayerSpatial<Dtype>::create_convolution_kernel(
   else if (kernelType == ConvType::GEMM_LIKE)
     create_gemm_like_conv_kernel(
         bottom, top, blockWidth, blockHeight, blockDepth);
+  else if (kernelType == ConvType::DWCONV)
+    create_dw_conv_kernel(
+        bottom, top, blockWidth, blockHeight, blockDepth);
   else
     assert(0);
 }
@@ -1498,6 +1604,10 @@ void ConvolutionLayerSpatial<Dtype>::setup_convolution(
     // Generates static key_
     int max_compute_units = ctx.current_device().max_compute_units();
     int kernelCnt = 0;
+    if(dwconv_) {
+      create_convolution_kernel(bottom, top, ConvType::DWCONV, 1, 1, 1);
+    }
+
     // Create WINOGRAD Kernels.
     if (!std::is_same<Dtype, double>::value &&this->group_ == 1 &&
         this->stride_w_ == 1 && this->stride_h_ == 1 &&
@@ -1860,7 +1970,7 @@ void ConvolutionLayerSpatial<Dtype>::load_cached_kernels(
     cachedKernel >> foo;
     cachedKernel >> bestKernelConfig->use_null_local;
     tuned_ = true;
-    // If kernel type changed to type 2 or 4, we need to reset the swizzled
+    // If kernel type changed to type IDLF or GEMMLIKE, we need to reset the swizzled
     // weights pointer to invalidate the previous swizzled weights data.
     if (prev_kernel_type != bestKernelConfig->kernelType &&
         (bestKernelConfig->kernelType == ConvType::IDLF ||

--- a/tools/inference-optimize/model_fuse.py
+++ b/tools/inference-optimize/model_fuse.py
@@ -15,7 +15,7 @@ from pdb import set_trace
 def resnet_block_to_fuse_type(model, cur_conv_index):
     maxindex = len(model.layer)-1
     if cur_conv_index+1>maxindex:
-        return 0 #UNFUSED
+        return 0,0 #UNFUSED
     elif  cur_conv_index+2>maxindex:
         actual = [model.layer[cur_conv_index+1].type, 'xxx', 'xxx', 'xxx']
     elif  cur_conv_index+3>maxindex:


### PR DESCRIPTION
Hi @gongzg 
This patch enable detphwise conv used by mobilenet, including:
1, enable basic depthwise conv kernel and passed all the test.
2, fixed a little bug on model_fuse python file
3. added mobilenet classification deploy prototxt and cpass tests of classification.

The caffemodel using for classication validation can be found on ```https://github.com/shicai/MobileNet-Caffe```