### PR TITLE
Integer/float incompatibility with python3.5.2+

### DIFF
--- a/python/caffe/classifier.py
+++ b/python/caffe/classifier.py
@@ -92,7 +92,7 @@ class Classifier(caffe.Net):
 
         # For oversampling, average predictions across crops.
         if oversample:
-            predictions = predictions.reshape((len(predictions) / 10, 10, -1))
+            predictions = predictions.reshape((int(len(predictions) / 10), 10, -1))
             predictions = predictions.mean(1)
 
         return predictions


### PR DESCRIPTION
Enforces that the division in reshape has an integer value, and avoids a runtime error.