### PR TITLE
correct type cast for operator ? 0 : half

### DIFF
--- a/src/caffe/layers/accuracy_layer.cpp
+++ b/src/caffe/layers/accuracy_layer.cpp
@@ -95,7 +95,7 @@ void AccuracyLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
   if (top.size() > 1) {
     for (int_tp i = 0; i < top[1]->count(); ++i) {
       top[1]->mutable_cpu_data()[i] =
-          nums_buffer_.cpu_data()[i] == 0 ? 0
+          nums_buffer_.cpu_data()[i] == 0 ? Dtype(0)
           : top[1]->cpu_data()[i] / nums_buffer_.cpu_data()[i];
     }
   }


### PR DESCRIPTION
For operator *?0:v, v is converted into integer if the data type of
v is half. Just explicitly point the expected data type with Dtype(0),
so the values are promoted to float, instead of integer.