### PR TITLE
Fixed ocl compiling error of winograd function

### DIFF
--- a/src/caffe/greentea/cl_kernels.cpp
+++ b/src/caffe/greentea/cl_kernels.cpp
@@ -2637,7 +2637,7 @@ static std::vector<std::vector<std::string>> cl_kernels{
 "#if APPLY_BIAS",    // NOLINT
 "Dtype bias = biases[(fm % ALIGNED_NUM_FILTERS)];",    // NOLINT
 "#else",    // NOLINT
-"Dtype bias = 0.",    // NOLINT
+"Dtype bias = 0.;",    // NOLINT
 "#endif",    // NOLINT
 "/*",    // NOLINT
 "A^T = {1, 1, 1, 1, 1, 0,",    // NOLINT

--- a/src/caffe/greentea/cl_kernels/conv_layer_spatial.cl
+++ b/src/caffe/greentea/cl_kernels/conv_layer_spatial.cl
@@ -2058,7 +2058,7 @@ winograd_4x4(
 #if APPLY_BIAS
     Dtype bias = biases[(fm % ALIGNED_NUM_FILTERS)];
 #else
-    Dtype bias = 0.
+    Dtype bias = 0.;
 #endif
       /*
       A^T = {1, 1, 1, 1, 1, 0,

--- a/src/caffe/layers/conv_layer_spatial.cpp
+++ b/src/caffe/layers/conv_layer_spatial.cpp
@@ -746,7 +746,7 @@ cl_int ConvolutionLayerSpatial<Dtype>::convolve(
       kernel.arg(argIdx++, fixup_arg_type(negative_slope_));
     kernel.arg(argIdx++, WrapHandle((cl_mem)this->input_transform_blob_.gpu_data(), &ctx));
     kernel.arg(argIdx++, WrapHandle(winograd_weights_image_, &ctx));
-    kernel.arg(argIdx++, WrapHandle((cl_mem)this->blobs()[1]->gpu_data(), &ctx));
+    kernel.arg(argIdx++, WrapHandle((cl_mem) bias_, &ctx));
     kernel.arg(argIdx++, WrapHandle((cl_mem)top[index]->mutable_gpu_data(), &ctx));
     kernel.arg(argIdx++, (ushort)(ALIGN(output_w_,4)*9));
     kernel.arg(argIdx++, (ushort)(ALIGN(output_h_,4)/4));


### PR DESCRIPTION
Hi @gongzg 
The error cause by lacking a semicolon on the conv_spatial winograd file and bug when bias term is false on winograd enqueue