### PR TITLE
Fixed a syncmem data zero copy bug. 

### DIFF
--- a/include/caffe/syncedmem.hpp
+++ b/include/caffe/syncedmem.hpp
@@ -98,6 +98,9 @@ class SyncedMemory {
 #ifdef USE_CUDA
   void async_gpu_push(const cudaStream_t& stream);
 #endif  // USE_CUDA
+#ifdef USE_GREENTEA
+  void async_gpu_push();
+#endif //USE_GREENTEA
 #endif  // !CPU_ONLY
 
  private:

--- a/src/caffe/layers/base_data_layer.cpp
+++ b/src/caffe/layers/base_data_layer.cpp
@@ -107,6 +107,14 @@ void BasePrefetchingDataLayer<Dtype>::InternalThreadEntry() {
         }
       }
 #endif  // USE_CUDA
+#ifdef USE_GREENTEA
+      if (this->device_->backend() == BACKEND_OpenCL) {
+        batch->data_.data().get()->async_gpu_push();
+        if (this->output_labels_) {
+          batch->label_.data().get()->async_gpu_push();
+        }
+      }
+#endif
 #endif  // !CPU_ONLY
       prefetch_full_.push(batch);
     }

--- a/src/caffe/layers/base_data_layer.cu
+++ b/src/caffe/layers/base_data_layer.cu
@@ -7,15 +7,6 @@ namespace caffe {
 template<typename Dtype>
 void BasePrefetchingDataLayer<Dtype>::Forward_gpu(
     const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
-
-#ifdef USE_GREENTEA
-  // Direct async to GPU currently unsupported on OpenCL
-  if (this->device_->backend() == BACKEND_OpenCL) {
-    this->Forward_cpu(bottom, top);
-    return;
-  }
-#endif  // USE_GREENTEA
-
   if (prefetch_current_) {
     prefetch_free_.push(prefetch_current_);
   }

--- a/src/caffe/syncedmem.cpp
+++ b/src/caffe/syncedmem.cpp
@@ -397,8 +397,6 @@ void SyncedMemory::set_gpu_data(void* data) {
 #ifdef USE_GREENTEA
     CHECK(data);
     if (own_gpu_data_) {
-      viennacl::ocl::context &ctx = viennacl::ocl::get_context(
-          device_->id());
       CHECK_EQ(CL_SUCCESS, clReleaseMemObject(cl_gpu_mem_))
           << "OpenCL memory corruption";
     }


### PR DESCRIPTION
Hi @gongzg 
This patch fixed a syncmem data zero copy bug. When syncmen own_cpu_data_ is false, we can't manage the data size to align with zero copy size requirement. So add the own_cpu_data_ check condition to determine whether to do zero copy to_gpu function.