### PR TITLE
VideoAnalysis example for Host/Client service.

### DIFF
--- a/examples/video_analysis/video_analysis.cpp
+++ b/examples/video_analysis/video_analysis.cpp
@@ -259,33 +259,33 @@ void Detector<Dtype>::ShowResult(const vector<cv::Mat> &imgs,
                                  const vector<vector<detect_result>> objects,
                                  bool step_mode)
 {
-    for (int i = 0; i < objects.size(); i++) {
-      if (objects[i].size() == 0)
-        continue;
-      int frame_num = objects[i][0].imgid;
-      cv::Mat img = imgs[frame_num].clone();
-      for (int j = 0; j < objects[i].size(); j++) {
-        detect_result obj = objects[i][j];
-	cv::rectangle(img,
-                      cvPoint(obj.left, obj.top),
-                      cvPoint(obj.right, obj.bottom),
-                      cv::Scalar(255, 242, 35));
-	std::stringstream ss;
-	ss << obj.classid << "/" << obj.confidence;
-	std::string  text = ss.str();
-	cv::putText(img,
-                    text,
-                    cvPoint(obj.left, obj.top + 20),
-                    cv::FONT_HERSHEY_PLAIN,
-                    1.0f,
-                    cv::Scalar(0, 255, 255));
-      }
-      cv::imshow("detections", img);
-      int wait_ms = step_mode ? 0 : 1;
-      int key = cv::waitKey(static_cast<char>(wait_ms));
-      if (key == 'q')
-        exit(1);
+  for (int i = 0; i < objects.size(); i++) {
+    if (objects[i].size() == 0)
+      continue;
+    int frame_num = objects[i][0].imgid;
+    cv::Mat img = imgs[frame_num].clone();
+    for (int j = 0; j < objects[i].size(); j++) {
+      detect_result obj = objects[i][j];
+      cv::rectangle(img,
+                    cvPoint(obj.left, obj.top),
+                    cvPoint(obj.right, obj.bottom),
+                    cv::Scalar(255, 242, 35));
+      std::stringstream ss;
+      ss << obj.classid << "/" << obj.confidence;
+      std::string  text = ss.str();
+      cv::putText(img,
+                  text,
+                  cvPoint(obj.left, obj.top + 20),
+                  cv::FONT_HERSHEY_PLAIN,
+                  1.0f,
+                  cv::Scalar(0, 255, 255));
     }
+    cv::imshow("detections", img);
+    int wait_ms = step_mode ? 0 : 1;
+    int key = cv::waitKey(static_cast<char>(wait_ms));
+    if (key == 'q')
+      exit(1);
+  }
 }
 
 // Normalized coordinate fixup for yolo

--- a/examples/video_analysis_host_client/video_analysis_client.cpp
+++ b/examples/video_analysis_host_client/video_analysis_client.cpp
@@ -1,0 +1,169 @@
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include <math.h>
+#include <cassert>
+#include <boost/filesystem.hpp>
+#include <caffe/caffe.hpp>
+#include "caffe/device.hpp"
+#include "caffe/util/benchmark.hpp"
+#include "caffe/mqueue.hpp"
+
+// using namespace caffe;
+using caffe::Blob;
+using caffe::Caffe;
+using caffe::Net;
+using caffe::Layer;
+using caffe::Solver;
+using caffe::shared_ptr;
+using caffe::string;
+using caffe::Timer;
+using caffe::vector;
+using caffe::device;
+using std::ostringstream;
+using namespace simple_mqueue;
+
+DEFINE_string(model, "",
+    "The model definition protocol buffer text file.");
+DEFINE_string(weights, "",
+    "Optional; the pretrained weights to initialize finetuning, "
+    "separated by ','. Cannot be set simultaneously with snapshot.");
+DEFINE_int32(float_width, 16,
+    "Optional; the Dtype used for client computation.");
+DEFINE_string(host_ip, "127.0.0.1",
+    "Requred; The host ip needed to connect to host,"
+    "The default setting is 127.0.0.1.");
+DEFINE_int32(port, 50000,
+    "Required; The host port to connect,"
+    "The default id is 50000");
+
+
+template<typename Dtype>
+class DNNClientContext : public simple_mqueue::BasicContext<Dtype, Dtype> {
+public:
+  DNNClientContext() {
+    weight_initialized = false;
+    input_msg_ = nullptr;
+    output_msg_ = nullptr;
+
+    /* Load the network. */
+    net_.reset(new Net<Dtype>(FLAGS_model, caffe::TEST, Caffe::GetDefaultDevice()));
+    net_->CopyTrainedLayersFrom(FLAGS_weights);
+    CHECK_EQ(net_->num_inputs(), 1) << "Network should have exactly one input.";
+    CHECK_EQ(net_->num_outputs(), 1) << "Network should have exactly one output.";
+  }
+
+  virtual ~DNNClientContext() {
+    for (unsigned int i = 0; i < allocated_messages.size(); i++)
+      delete allocated_messages[i];
+  }
+
+  void prepare_messages(vector<Message<Dtype> *> &msgs) {
+    if (input_msg_ == nullptr) {
+      Blob<Dtype>* input_layer = net_->input_blobs()[0];
+      Blob<Dtype>* output_layer = net_->output_blobs()[0];
+      input_msg_ = new Message<Dtype> (InputData, input_layer->shape(0),
+                                       input_layer->shape(1), input_layer->shape(2),
+                                       input_layer->shape(3));
+      output_msg_ = new Message<Dtype> (OutputData, 1, 1, output_layer->shape(0),
+                                        output_layer->shape(1));
+      allocated_messages.push_back(input_msg_);
+      allocated_messages.push_back(output_msg_);
+    }
+    msgs.push_back(input_msg_);
+  }
+
+  // FIXME zero copy ?
+  int CopyWeight(Dtype *data, Blob<Dtype> &blob) {
+    //memcpy(blob->mutable_cpu_data(), data, blob->count(0) * sizeof(Dtype));
+    blob.set_cpu_data(data);
+    return blob.count(0);
+  }
+
+
+  void handle_input_messages(vector<Message<Dtype> *> & msgs,
+                             vector<Message<Dtype> *> & output_msgs) {
+
+    Blob<Dtype>* input_blob = net_->input_blobs()[0];
+    input_blob->Reshape(msgs[0]->memory()->shape()[0],
+                msgs[0]->memory()->shape()[1],
+                msgs[0]->memory()->shape()[2],
+                msgs[0]->memory()->shape()[3]);
+    input_blob->set_cpu_data(msgs[0]->mutable_memory()->mutable_data());
+    net_->Reshape();
+    net_->Forward();
+    caffe::Caffe::Synchronize(caffe::Caffe::GetDefaultDevice()->id());
+
+    Blob<Dtype> *out = net_->output_blobs()[0];
+    output_msg_->mutable_memory()->set_data(out->count(0), out->mutable_cpu_data());
+    output_msg_->mutable_memory()->reshape(out->shape(0), out->shape(1), out->shape(2), out->shape(3));
+    output_msgs.push_back(output_msg_);
+  }
+
+  void handle_messages(vector<Message<Dtype> *> &msgs, vector<Message<Dtype> *> &output_msgs) {
+    if (msgs[0]->id() == InitWeight) {
+    } else if (msgs[0]->id() == InputData) {
+      // Do inference here.
+      handle_input_messages(msgs, output_msgs);
+    }
+  }
+
+private:
+  shared_ptr<Net<Dtype> > net_;
+  vector<Message<Dtype> *> allocated_messages;
+  bool weight_initialized;
+  int batch_size_;
+  Message<Dtype> * input_msg_;
+  Message<Dtype> * output_msg_;
+};
+
+int main(int argc, char **argv) {
+
+  if (std::getenv("HOME")) {
+    std::stringstream cache_path;
+    cache_path << std::getenv("HOME") << "/.cache/";
+    const boost::filesystem::path& path = cache_path.str();
+    const boost::filesystem::path& dir =
+                 boost::filesystem::unique_path(path).string();
+    if (!boost::filesystem::exists(dir))
+      boost::filesystem::create_directories(dir);
+    setenv("VIENNACL_CACHE_PATH", cache_path.str().c_str(), true);
+  }
+
+  caffe::GlobalInit(&argc, &argv);
+  caffe::Caffe::set_mode(caffe::Caffe::GPU);
+  caffe::Caffe::SetDevice(0);
+  std::string host_ip = FLAGS_host_ip;
+  uint16_t port = (uint16_t)FLAGS_port;
+  int float_width = FLAGS_float_width;
+
+  if (float_width != 16 && float_width != 32) {
+    printf("Invalid float width %d\n", float_width);
+    return -1;
+  }
+
+  printf("Host ip %s port %d\n", host_ip.c_str(), port);
+  printf("Using fp%d\n", float_width);
+  CHECK_GT(FLAGS_model.size(), 0) << "Need a model definition to forward.";
+  CHECK_GT(FLAGS_weights.size(), 0) << "Need model weights to forward.";
+  if (FLAGS_float_width == 16) {
+    while (1) {
+      DNNClientContext <half> client_ctx;
+      simple_mqueue::Node<half, half> client_node(simple_mqueue::NodeTypeClient, &client_ctx);
+      client_ctx.set_batch_size(16);
+      client_node.set_host_addr(host_ip.c_str(), port);
+      client_node.Run();
+    }
+  } else {
+    while (1) {
+      DNNClientContext <float> client_ctx;
+      simple_mqueue::Node<float, float> client_node(simple_mqueue::NodeTypeClient, &client_ctx);
+      client_ctx.set_batch_size(16);
+      client_node.set_host_addr(host_ip.c_str(), port);
+      client_node.Run();
+    }
+  }
+  caffe::Caffe::TeardownDevice(0);
+
+  return 0;
+}

--- a/examples/video_analysis_host_client/video_analysis_host.cpp
+++ b/examples/video_analysis_host_client/video_analysis_host.cpp
@@ -1,0 +1,631 @@
+#ifdef USE_OPENCV
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#endif  // USE_OPENCV
+#include <algorithm>
+#include <iomanip>
+#include <iosfwd>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+#include <chrono>
+#include <thread>
+#include <math.h>
+#include "caffe/data_transformer.hpp"
+#include <caffe/caffe.hpp>
+#include "caffe/mqueue.hpp"
+
+// using namespace caffe;
+using caffe::Blob;
+using caffe::Caffe;
+using caffe::Net;
+using caffe::Layer;
+using caffe::Solver;
+using caffe::shared_ptr;
+using caffe::string;
+using caffe::Timer;
+using caffe::vector;
+using caffe::device;
+using std::ostringstream;
+using caffe::DataTransformer;
+
+#if defined(USE_OPENCV)
+// using namespace caffe;  // NOLINT(build/namespaces)
+using namespace simple_mqueue;
+
+struct WeightHdr {
+  int input_size;
+  int state_size;
+  int output_size;
+};
+
+template<typename ClientDtype, typename HostDtype>
+class DNNHostContext : public BasicContext<ClientDtype, HostDtype> {
+public:
+  DNNHostContext() {}
+
+  Message<ClientDtype> *prepare_message(MessageID id) {
+    if (id == InitWeight) {
+      return weights_;
+    }
+    return nullptr;
+  }
+
+  virtual ~DNNHostContext(void) {
+
+    if (weights_ != nullptr) {
+      delete [] weights_->mutable_memory()->mutable_data();
+      delete [] weights_->mutable_extra_memory()->mutable_data();
+      delete weights_;
+    }
+    weights_ = nullptr;
+  }
+
+private:
+   Message<ClientDtype> *weights_ = nullptr;
+};
+
+
+struct detect_result {
+  int imgid;
+  float classid;
+  float confidence;
+  float left;
+  float right;
+  float top;
+  float bottom;
+};
+
+enum ColorFormat {
+  VA_RGB = 0,
+  VA_BGR = 1
+};
+
+template <typename Dtype>
+class Detector {
+public:
+  Detector(const string& model_file,
+           const string& weights_file,
+           int gpu,
+           int batch_size);
+  void Preprocess(const vector<cv::Mat> &imgs);
+
+  void Detect(vector<vector<detect_result>> &result,
+              int iter_count,
+              bool visualize = false,
+              bool step_mode = false);
+
+  void ShowResult(const vector<cv::Mat> &imgs,
+                  const vector<vector<detect_result>> objects,
+                  bool step_mode);
+  ~Detector() {
+    for (int i = 0; i < input_blobs_.size(); i++)
+      delete input_blobs_[i];
+    delete data_transformer_;
+    if (host_node_ != nullptr)
+      delete host_node_;
+    if (host_ctx_ != nullptr)
+      delete host_ctx_;
+  }
+
+private:
+
+  caffe::shared_ptr<Net<Dtype> > net_;
+  cv::Size input_blob_size_;
+  cv::Size image_size_;
+  int num_channels_;
+  int batch_size_;
+  bool use_yolo_format_;
+  bool faster_rcnn;
+  vector<Blob<Dtype>*> input_blobs_;
+  const vector<cv::Mat> *origin_imgs_;
+  DataTransformer<Dtype> *data_transformer_;
+  ColorFormat input_color_format_;
+
+  std::string host_ip_;
+  uint16_t host_port_;
+  int client_batch_size_;
+  int client_num_;
+
+  DNNHostContext<Dtype, Dtype> *host_ctx_ = nullptr;
+  // Host node to distribute dnn work load to multiple clients.
+  Node<Dtype, Dtype> *host_node_ = nullptr;
+
+  unsigned int output_size_;
+
+  Message<Dtype>* input_message_ = nullptr;
+  Message<Dtype>* output_message_ = nullptr;
+};
+
+template <typename Dtype>
+Detector<Dtype>::Detector(const string& model_file,
+                   const string& weights_file,
+                   int gpu,
+                   int batch_size) {
+  // Set the host IP address.
+  if (std::getenv("INTEL_VCA_LSTM_HOST_IP")) {
+    host_ip_ = std::getenv("INTEL_VCA_LSTM_HOST_IP");
+  } else {
+    host_ip_ = "127.0.0.1";
+  }
+  // Set the host server port number
+  if (std::getenv("INTEL_VCA_LSTM_HOST_PORT")) {
+    host_port_ = atoi(std::getenv("INTEL_VCA_LSTM_HOST_PORT"));
+  } else {
+    host_port_ = 50000;
+  }
+  // Set how many clients(nodes) we have
+  if (std::getenv("INTEL_VCA_LSTM_CLIENT_NUM")) {
+    client_num_ = atoi(std::getenv("INTEL_VCA_LSTM_CLIENT_NUM"));
+  } else {
+    client_num_ = 1;
+  }
+  // Set batch size for each client.
+  client_batch_size_ = 16;
+
+  std::cout << "Use CPU" << std::endl;
+  Caffe::set_mode(Caffe::CPU);
+
+  batch_size_ = batch_size;
+  /* Load the network. */
+  net_.reset(new Net<Dtype>(model_file, caffe::TEST, Caffe::GetDefaultDevice()));
+  net_->CopyTrainedLayersFrom(weights_file);
+
+  CHECK_EQ(net_->num_outputs(), 1) << "Network should have exactly one output.";
+
+  Blob<Dtype>* input_layer = net_->input_blobs()[0];
+  num_channels_ = input_layer->channels();
+  CHECK(num_channels_ == 3 || num_channels_ == 1)
+    << "Input layer should have 1 or 3 channels.";
+  input_blob_size_ = cv::Size(input_layer->width(), input_layer->height());
+
+  // Check whether the model we will using.
+  // Different models need different preprocessing parameters.
+  const shared_ptr<Layer<Dtype>> output_layer = net_->layers().back();
+  caffe::TransformationParameter transform_param;
+  caffe::ResizeParameter *resize_param = transform_param.mutable_resize_param();
+  faster_rcnn = false;
+  if (output_layer->layer_param().type() == "FasterRcnnDetectionOutput") {
+    faster_rcnn = true;
+    input_color_format_ = VA_BGR;
+    std::cout << "Using Faster RCNN: " << net_->name() << std::endl;
+    CHECK(num_channels_ == 3) << "Input layer should have 3 channels.";
+    CHECK(batch_size_ == 1) << "batch size should be 1.";
+    return;
+  } else if (output_layer->layer_param().type() == "YoloDetectionOutput") {
+    use_yolo_format_ = !output_layer->layer_param().
+                        yolo_detection_output_param().ssd_format();
+    resize_param->set_resize_mode(caffe::ResizeParameter_Resize_mode_FIT_LARGE_SIZE_AND_PAD);
+    resize_param->add_pad_value(127.5);
+    transform_param.set_scale(1./255.);
+    transform_param.set_force_color(true);
+    std::cout << "Using Yolo: " << net_->name() << std::endl;
+    input_color_format_ = VA_RGB;
+  } else if (output_layer->layer_param().type() == "DetectionOutput") {
+    use_yolo_format_ = false;
+    resize_param->set_resize_mode(caffe::ResizeParameter_Resize_mode_WARP);
+    if (net_->name().find("MobileNet") != std::string::npos) {
+      transform_param.add_mean_value(127.5);
+      transform_param.add_mean_value(127.5);
+      transform_param.add_mean_value(127.5);
+      transform_param.set_scale(1./127.5);
+      std::cout << "Using SSD(MobileNet)." << std::endl;
+    } else {
+      // For standard SSD VGG or DSOD
+      transform_param.add_mean_value(104);
+      transform_param.add_mean_value(117);
+      transform_param.add_mean_value(123);
+      std::cout << "Using SSD : " << net_->name() << std::endl;
+    }
+    input_color_format_ = VA_BGR;
+  } else {
+    std::cerr << "The model is not a valid object detection model."
+              << std::endl;
+    exit(-1);
+  }
+  resize_param->set_width(input_blob_size_.width);
+  resize_param->set_height(input_blob_size_.height);
+  resize_param->set_prob(1.0);
+  resize_param->add_interp_mode(caffe::ResizeParameter_Interp_mode_LINEAR);
+  data_transformer_ = new DataTransformer<Dtype>(transform_param,
+                                                 caffe::TEST,
+                                                 Caffe::GetDefaultDevice());
+
+  host_ctx_ = new DNNHostContext<Dtype, Dtype>();
+  host_ctx_->set_batch_size(client_batch_size_);
+  host_node_ = new Node<Dtype, Dtype>(NodeTypeHost,
+                                          host_ctx_,
+                                          client_num_);
+  host_node_->set_host_addr(host_ip_.c_str(), host_port_);
+  host_node_->Run();
+}
+
+static void
+FixupChannels(vector <cv::Mat> &imgs, int num_channels,
+              enum ColorFormat color_format) {
+  for (int i = 0; i < imgs.size(); i++) {
+    /* Convert the input image to the input image format of the network. */
+    cv::Mat img = imgs[i];
+    if (img.channels() != num_channels) {
+      cv::Mat sample;
+      if (img.channels() == 3 && num_channels == 1)
+        cv::cvtColor(img, sample, cv::COLOR_BGR2GRAY);
+      else if (img.channels() == 4 && num_channels == 1)
+        cv::cvtColor(img, sample, cv::COLOR_BGRA2GRAY);
+      else if (img.channels() == 4 && num_channels == 3)
+        cv::cvtColor(img, sample,
+                     color_format == VA_BGR ?
+                     cv::COLOR_BGRA2BGR : cv::COLOR_BGRA2RGB);
+      else if (img.channels() == 1 && num_channels == 3)
+        cv::cvtColor(img, sample,
+                     color_format == VA_BGR ?
+                     cv::COLOR_GRAY2BGR : cv::COLOR_BGRA2RGB);
+      else {
+        // Should not enter here, just in case.
+        if (color_format == VA_BGR)
+          sample = img;
+        else
+          cv::cvtColor(img, sample, cv::COLOR_BGR2RGB);
+      }
+      imgs[i] = sample;
+    }
+  }
+}
+
+template <typename Dtype>
+void Detector<Dtype>::Preprocess(const vector<cv::Mat> &imgs) {
+
+  if (imgs.size() == 0)
+    return;
+  origin_imgs_ = & imgs;
+  int batch_id = 0;
+
+  image_size_.width = imgs[0].cols;
+  image_size_.height = imgs[0].rows;
+  int batch_count = imgs.size() / batch_size_;
+
+  if (faster_rcnn) {
+    static int MAX_SIZE = 1000;
+    static int SCALE_SIZE = 600;
+    int img_size_min = std::min(image_size_.width, image_size_.height);
+    int img_size_max = std::max(image_size_.width, image_size_.height);
+    float scale = SCALE_SIZE * 1.0 / img_size_min;
+    if (scale * img_size_max > MAX_SIZE)
+      scale = MAX_SIZE * 1.0 / img_size_max;
+
+    input_blob_size_.width = (int)(scale * image_size_.width);
+    input_blob_size_.height = (int)(scale * image_size_.height);
+
+    caffe::TransformationParameter transform_param;
+    caffe::ResizeParameter *resize_param = transform_param.mutable_resize_param();
+
+    transform_param.add_mean_value(102.9801);
+    transform_param.add_mean_value(115.9465);
+    transform_param.add_mean_value(122.7717);
+
+    resize_param->set_resize_mode(caffe::ResizeParameter_Resize_mode_WARP);
+    resize_param->set_width(input_blob_size_.width);
+    resize_param->set_height(input_blob_size_.height);
+    resize_param->set_prob(1.0);
+    resize_param->add_interp_mode(caffe::ResizeParameter_Interp_mode_LINEAR);
+    data_transformer_ = new DataTransformer<Dtype>(transform_param,
+                                                 caffe::TEST,
+                                                 Caffe::GetDefaultDevice());
+  }
+
+  for (batch_id = 0; batch_id < batch_count; batch_id++) {
+    Blob<Dtype> * blob = new Blob<Dtype>;
+    blob->Reshape(batch_size_,
+                  num_channels_,
+                  input_blob_size_.height,
+                  input_blob_size_.width);
+    int pos = batch_id * batch_size_;
+    vector<cv::Mat> batch_imgs(imgs.begin() + pos,
+                               imgs.begin() + pos + batch_size_);
+    FixupChannels(batch_imgs, num_channels_, input_color_format_);
+    data_transformer_->Transform(batch_imgs, blob);
+    input_blobs_.push_back(blob);
+  }
+
+  if (batch_id * batch_size_ < imgs.size()) {
+    Blob<Dtype> * blob = new Blob<Dtype>;
+    blob->Reshape(imgs.size() - batch_id * batch_size_,
+                  num_channels_,
+                  input_blob_size_.height,
+                  input_blob_size_.width);
+    int pos = batch_id * batch_size_;
+    int batch_size = imgs.size() - batch_id * batch_size_;
+    const vector<cv::Mat> batch_imgs(imgs.begin() + pos,
+                                     imgs.begin() + pos + batch_size);
+    input_blobs_.push_back(blob);
+  }
+}
+
+template <typename Dtype>
+void Detector<Dtype>::ShowResult(const vector<cv::Mat> &imgs,
+                                 const vector<vector<detect_result>> objects,
+                                 bool step_mode)
+{
+  for (int i = 0; i < objects.size(); i++) {
+    if (objects[i].size() == 0)
+      continue;
+    int frame_num = objects[i][0].imgid;
+    cv::Mat img = imgs[frame_num].clone();
+    for (int j = 0; j < objects[i].size(); j++) {
+      detect_result obj = objects[i][j];
+      cv::rectangle(img,
+                    cvPoint(obj.left, obj.top),
+                    cvPoint(obj.right, obj.bottom),
+                    cv::Scalar(255, 242, 35));
+      std::stringstream ss;
+      ss << obj.classid << "/" << obj.confidence;
+      std::string  text = ss.str();
+      cv::putText(img,
+                  text,
+                  cvPoint(obj.left, obj.top + 20),
+                  cv::FONT_HERSHEY_PLAIN,
+                  1.0f,
+                  cv::Scalar(0, 255, 255));
+    }
+    cv::imshow("detections", img);
+#if 1
+    int wait_ms = step_mode ? 0 : 1;
+    int key = cv::waitKey(static_cast<char>(wait_ms));
+    if (key == 'q')
+      exit(1);
+#endif
+  }
+}
+
+// Normalized coordinate fixup for yolo
+float fixup_norm_coord(float coord, float ratio) {
+  if (ratio >= 1)
+    return coord;
+  else
+    return (coord - (1. - ratio)/2) / ratio;
+}
+
+template <typename Dtype>
+void Detector<Dtype>::Detect(vector<vector<detect_result>> &all_objects,
+                             int iter_count,
+                             bool visualize,
+                             bool step_mode) {
+  int batch_to_detect = iter_count * input_blobs_.size();
+  // iter_count 0 is for warm up to handle only 1 batch.
+  if (batch_to_detect == 0)
+    batch_to_detect = 1;
+  int w = image_size_.width;
+  int h = image_size_.height;
+
+  Blob<Dtype>* input_layer = net_->input_blobs()[0];
+  input_layer->ReshapeLike(*input_blobs_[0]);
+
+  Blob<Dtype> * iminfo_blob = new Blob<Dtype>;
+  if (faster_rcnn) {
+    iminfo_blob->Reshape(std::vector<int>{1, 3});
+    Dtype* data = iminfo_blob->mutable_cpu_data();
+    data[0] = input_blobs_[0]->height();
+    data[1] = input_blobs_[0]->width();
+    data[2] = input_blobs_[0]->width() * 1.0 / w;
+    (net_->input_blobs()[1])->ReshapeLike(*iminfo_blob);
+    (net_->input_blobs()[1])->ShareData(*iminfo_blob);
+  }
+
+  net_->Reshape();
+  Blob<Dtype>* result_blob = net_->output_blobs()[0];
+  std::vector<int> out_shape(4, 1);
+  for(int i = 0; i < result_blob->num_axes(); ++i) {
+    out_shape[i] = result_blob->shape()[i];
+  }
+  output_message_ = new Message<Dtype>(OutputData, out_shape[0], out_shape[1], 21, out_shape[3]);
+  for (int batch_id = 0; batch_id < batch_to_detect; batch_id++) {
+    int real_batch_id = batch_id % input_blobs_.size();
+    int batch_size = input_blobs_[real_batch_id]->num();
+
+    std::vector<int> in_shape = input_blobs_[real_batch_id]->shape();
+    input_message_ = new Message<Dtype>(InputData, in_shape[0], in_shape[1], in_shape[2], in_shape[3], input_blobs_[real_batch_id]->mutable_cpu_data());
+
+    vector<Message<Dtype> *> input_messages;
+    input_messages.push_back(input_message_);
+
+    vector<Message<Dtype> *> output_messages;
+    output_messages.push_back(output_message_);
+
+    // Ready to send messages to clients.
+    host_node_->Forward(input_messages, output_messages);
+
+    const Dtype* result = output_message_->memory()->data();
+    const int num_det = output_message_->memory()->shape()[2];
+    vector<vector<detect_result>> objects(batch_size);
+    for (int k = 0; k < num_det * 7; k += 7) {
+      detect_result object;
+      object.imgid = (int)result[k + 0] + real_batch_id * batch_size;
+      object.classid = (int)result[k + 1];
+      object.confidence = result[k + 2];
+      if (faster_rcnn) {
+        object.left = (int)(result[k + 3]);
+        object.top = (int)(result[k + 4]);
+        object.right = (int)(result[k + 5]);
+        object.bottom = (int)(result[k + 6]);
+      } else {
+        if (use_yolo_format_) {
+          object.left = (int)(fixup_norm_coord((result[k + 3] -
+                           result[k + 5] / 2.0), float(w) / h) * w);
+          object.right = (int)(fixup_norm_coord((result[k + 3] +
+                           result[k + 5] / 2.0), float(w) / h) * w);
+          object.top = (int)(fixup_norm_coord((result[k + 4] -
+                          result[k + 6] / 2.0), float(h) / w) * h);
+          object.bottom = (int)(fixup_norm_coord((result[k + 4] +
+                             result[k + 6] / 2.0), float(h) / w) * h);
+        } else {
+          object.left = (int)(result[k + 3] * w);
+          object.top = (int)(result[k + 4] * h);
+          object.right = (int)(result[k + 5] * w);
+          object.bottom = (int)(result[k + 6] * h);
+        }
+        if (object.left < 0) object.left = 0;
+        if (object.top < 0) object.top = 0;
+        if (object.right >= w) object.right = w - 1;
+        if (object.bottom >= h) object.bottom = h - 1;
+      }
+      objects[result[k + 0]].push_back(object);
+    }
+    if (visualize)
+      ShowResult(*origin_imgs_, objects, step_mode);
+      all_objects.insert(all_objects.end(), objects.begin(), objects.end());
+
+    delete input_message_;
+    // delete output_message_;
+  }
+
+  delete output_message_;
+  delete iminfo_blob;
+}
+
+int main(int argc, char** argv) {
+
+#if CV_MAJOR_VERSION >= 3
+  const char* keys =
+    "{ model model_file      | <none> | model file }"
+    "{ weights weights_file  | <none> | weights file }"
+    //"{ img image             | <none> | path to image }"
+    "{ video                 | <none> | path to video }"
+    //"{ out out_file          |        | output image file }"
+    "{ s step                | false  | true for step mode }"
+    "{ i iter                | 1      | iterations to be run }"
+    "{ v visualize           | false   | visualize output }"
+    "{ g gpu                 | 0      | gpu device }"
+    "{ c cpu                 | false  | use cpu device }"
+    "{ fp16 use_fp16         | false  | use fp16 forward engine. }"
+    "{ bs batch_size         | 1      | batch size }"
+    "{ frame_count f         | 1024   | process frame count in the video}"
+    "{ help                  | false  | display this help and exit  }"
+    ;
+#else
+  const char* keys =
+    "{ model   | model_file      | <none> | model file }"
+    "{ weights | weights_file    | <none> | weights file }"
+    //"{ img     | image           | <none> | path to image }"
+    "{ video   | video           | <none> | path to video }"
+    //"{ out     | out_file        |        | output image file }"
+    "{ s       | step            | false  | true for step mode }"
+    "{ i       | iter            | 1      | iterations to be run }"
+    "{ v       | visualize       | false   | visualize output }"
+    "{ g       | gpu             | 0     | gpu device }"
+    "{ c       | cpu             | false | use cpu device }"
+    "{ fp16    | use_fp16        | false  | use fp16 forward engine. }"
+    "{ bs      | batch_size      | 1      | batch size }"
+    "{ f       | frame_count     | 1024   | process frame count in the video}"
+    "{ h       | help            | false  | display this help and exit  }"
+    ;
+#endif
+
+  cv::CommandLineParser parser(argc, argv, keys);
+  const string model_file = parser.get<std::string>("model_file");
+  const string weights_file = parser.get<std::string>("weights_file");
+  const string video_file = parser.get<std::string>("video");
+  int iter = parser.get<int>("iter");
+  bool visualize = parser.get<bool>("visualize");
+  int gpu = parser.get<int>("gpu");
+  bool cpu = parser.get<bool>("cpu");
+  int batch_size = parser.get<int>("batch_size");
+  bool use_fp16 = parser.get<bool>("use_fp16");
+  bool step_mode = parser.get<bool>("step");
+  int max_frame_count = parser.get<int>("frame_count");
+
+  if (model_file == "" ||
+      weights_file == "" ||
+      video_file == "") {
+#if CV_MAJOR_VERSION >= 3
+    parser.printMessage();
+#else
+    parser.printParams();
+#endif
+    exit(-1);
+  }
+
+  if (cpu)
+    gpu = -1;
+  std::streambuf* buf = std::cout.rdbuf();
+  std::ostream out(buf);
+  cv::VideoCapture cap_;
+  int total_frames = 0;
+  cv::Mat tmpMat;
+
+  if (!cap_.open(video_file))
+    LOG(FATAL) << "Failed to open video: " << video_file;
+
+  total_frames = cap_.get(CV_CAP_PROP_FRAME_COUNT);
+  total_frames = (total_frames > max_frame_count) ?
+                  max_frame_count : total_frames;
+  // For benchmark mode, we limit the frames to 8
+  if (!visualize && total_frames > 8)
+    total_frames = 8;
+  std::cout << "\nTotal frame number = " << total_frames;
+  vector<cv::Mat> imgCache(total_frames);
+  for (int i = 0; i < total_frames; i++) {
+    cap_ >> imgCache[i];
+  }
+
+  vector<vector<struct detect_result>> objects;
+  double warm_up_time = 0;
+  double detect_time = 0;
+  // Initialize the network.
+  if (use_fp16) {
+#ifdef HAS_HALF_SUPPORT
+    Detector<half> detector(model_file, weights_file, gpu, batch_size);
+    Timer warm_up_timer, detect_timer;
+    detector.Preprocess(imgCache);
+    // Detect one batch to warm up.
+    warm_up_timer.Start();
+    detector.Detect(objects, 0);
+    detector.Detect(objects, 0);
+    warm_up_timer.Stop();
+    objects.clear();
+    warm_up_time = warm_up_timer.MilliSeconds();
+
+    detect_timer.Start();
+    detector.Detect(objects, iter, visualize, step_mode);
+    detect_timer.Stop();
+    detect_time = detect_timer.MilliSeconds();
+#else
+    std::cout << "fp16 is not supported." << std::endl;
+#endif
+  } else {
+    Detector<float> detector(model_file, weights_file, gpu, batch_size);
+    Timer warm_up_timer, detect_timer;
+    detector.Preprocess(imgCache);
+    // Detect one batch to warm up.
+    warm_up_timer.Start();
+    detector.Detect(objects, 0);
+    warm_up_timer.Stop();
+    objects.clear();
+    warm_up_time = warm_up_timer.MilliSeconds();
+    detect_timer.Start();
+    detector.Detect(objects, iter, visualize, step_mode);
+    detect_timer.Stop();
+    detect_time = detect_timer.MilliSeconds();
+  }
+
+  std::cout << "Warm up time is "
+            << warm_up_time
+            << "ms." << std::endl;
+
+  std::cout << "Detect time is "
+            << detect_time
+            << "ms." << std::endl;
+
+  double fps = total_frames * iter / (detect_time / 1000.);
+  std::cout << "Average frames per second is " << fps << "." << std::endl
+            << "Average latency is " << 1000./fps << " ms." << std::endl;
+  return 0;
+}
+#else
+int main(int argc, char** argv) {
+    LOG(FATAL) << "This example requires OpenCV and half floating point support."
+        << "compile with USE_OPENCV and USE_ISAAC.";
+}
+#endif  // USE_OPENCV
+

--- a/include/caffe/mqueue.hpp
+++ b/include/caffe/mqueue.hpp
@@ -1,0 +1,647 @@
+#ifndef __SIMPLE_MQUEUE_HPP__
+#define __SIMPLE_MQUEUE_HPP__
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <vector>
+#include <map>
+#include <sys/epoll.h>
+#include <cstddef>
+#include <type_traits>
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <iostream>
+#include <unistd.h>
+#include "caffe/3rdparty/half/half.hpp"
+
+using namespace half_float;
+
+namespace simple_mqueue {
+
+//using namespace std;
+
+enum NodeType {
+  NodeTypeClient,
+  NodeTypeHost
+};
+
+enum MessageID {
+  InitWeight = 0,
+  InputData = 1,
+  OutputData = 2,
+  ExitMessage = 9999,
+};
+
+enum MessageDataType {
+  FP16 = 0,
+  FP32 = 1,
+  UNSUPPORTED = 9,
+};
+
+template <typename Dtype>
+MessageDataType GetDataType(void)
+{
+  if (std::is_same<Dtype, half>::value)
+    return FP16;
+  if (std::is_same<Dtype, float>::value)
+    return FP32;
+  return UNSUPPORTED;
+}
+
+template <typename Dtype>
+struct MessageHdr {
+
+  MessageHdr(): id() {
+  }
+
+  MessageHdr(MessageID id): id(id) {
+    data_type = GetDataType<Dtype>();
+  }
+  uint16_t data_type;
+  uint16_t id;
+  uint32_t shape[4];
+  int len() {
+    return shape[0] * shape[1] * shape[2] * shape[3];
+  }
+  uint32_t extra_shape_len;
+};
+
+template<typename Dtype>
+class Memory {
+public:
+  Memory(int batch, int channel, int h, int w) {
+    own_data_ = false;
+    allocate(batch * channel * h * w * sizeof(Dtype));
+    reshape(batch, channel, h, w);
+  }
+  Memory(int batch, int channel, int h, int w, Dtype *data) {
+    data_ = data;
+    data_len_ = batch * channel * h * w;
+    own_data_ = false;
+    reshape(batch, channel, h, w);
+  }
+  Memory(int len, Dtype *data) {
+    data_ = data;
+    data_len_ = len;
+    own_data_ = false;
+    reshape(1,1,1,len);
+  }
+  ~Memory(void) {
+    if (own_data_)
+      free(data_);
+    own_data_ = false;
+    data_ = NULL;
+  }
+  int data_len() const { return data_len_; }
+  bool own_data() const { return own_data_; }
+  const Dtype * data() const { return data_; }
+  Dtype * mutable_data() { return data_; }
+  void set_data(int len, Dtype *data) {
+    if (data_ && own_data_)
+      free(data_);
+    data_ = data;
+    own_data_ = false;
+    data_len_ = len;
+  }
+
+  void set_data(Dtype *data) {
+    if (data_ && own_data_)
+      free(data_);
+    data_ = data;
+    own_data_ = false;
+  }
+
+  Dtype &at(int b, int c, int h, int w) {
+    return data_[b * count(1) + c * count(2) + h * count(3) + w];
+  }
+
+  const Dtype &const_at(int b, int c, int h, int w) const {
+    return data_[b * count(1) + c * count(2) + h * count(3) + w];
+  }
+
+  void allocate(int size) {
+    if (data_ && own_data_)
+      free(data_);
+    data_ = (Dtype *)malloc(size * sizeof(Dtype));
+    data_len_ = size;
+    own_data_ = true;
+  }
+
+  int count(int start_id) const {
+    int size = 1;
+    for (unsigned int i = start_id ; i < shape_.size(); i++) {
+      size *= shape_[i];
+    }
+    return size;
+  }
+  void reshape(int batch, int channel, int h, int w) {
+    std::vector <int> shape;
+    shape.push_back(batch);
+    shape.push_back(channel);
+    shape.push_back(h);
+    shape.push_back(w);
+    reshape(shape);
+  }
+
+  void reshape(std::vector <int> shape) {
+    shape_.resize(4);
+    for (unsigned int i = 0; i < 4; i++) {
+      if (i < shape.size())
+        shape_[i] = shape[i];
+      else
+        shape_[i] = 1;
+    }
+    if (count(0) > data_len_ && own_data_) {
+      allocate(count(0));
+      assert(data_ != NULL);
+      if (data_ == NULL) {
+        printf("fail to allocate buffer for %d.\n", count(0));
+        exit(-1);
+      }
+    }
+    if (count(0) > data_len_ && !own_data_) {
+      printf("Try to reshape to larger size for an external memory block.\n");
+      exit(-1);
+    }
+  }
+  int batch_size() const { return shape_[0]; }
+  const std::vector <int> &shape() const { return shape_; }
+private:
+
+  std::vector <int> shape_;
+  int data_len_;
+  bool own_data_;
+  Dtype *data_;
+};
+
+template<typename DstDtype, typename SrcDtype>
+void memory_copy(Memory <DstDtype> *dst, const SrcDtype * src) {
+  DstDtype * dst_data = dst->mutable_data();
+  for (int i = 0; i < dst->count(0); i++)
+    dst_data[i] = src[i];
+}
+
+template void memory_copy<float, float>(Memory <float> *dst, const float *src);
+
+template<typename Dtype>
+class Message {
+public:
+  Message(MessageID id, int data_len) : id_(id) {
+    mem_ = new Memory<Dtype>(1, 1, 1, data_len);
+    extra_shape_ = NULL;
+  }
+  Message(MessageID id, int data_len, Dtype *data)
+    : id_(id) {
+    mem_ = new Memory<Dtype>(1, 1, 1, data_len, data);
+    extra_shape_ = NULL;
+  }
+  Message(MessageID id, int batch, int channel, int h, int w, Dtype *data) {
+    id_ = id;
+    mem_ = new Memory<Dtype>(batch, channel, h, w, data);
+    extra_shape_ = NULL;
+  }
+  Message(MessageID id, int batch, int channel, int h, int w) {
+    id_ = id;
+    mem_ = new Memory<Dtype>(batch, channel, h, w);
+    extra_shape_ = NULL;
+  }
+  Message(MessageID id, int batch, int channel, int h, int w,
+          int extra_shape_len) {
+    id_ = id;
+    mem_ = new Memory<Dtype>(batch, channel, h, w);
+    extra_shape_ = new Memory<int>(extra_shape_len, 1, 1, 1);
+  }
+
+  ~Message(void) {
+    if (mem_)
+      delete mem_;
+    if (extra_shape_)
+      delete extra_shape_;
+    mem_ = NULL;
+    extra_shape_ = NULL;
+  }
+  void set_id(MessageID id) { id_ = id; }
+  MessageID id() const { return id_; }
+  const Memory<Dtype> *memory() const { return mem_; }
+  Memory<Dtype> *mutable_memory() { return mem_; }
+  const Memory<int> *extra_memory() const { return extra_shape_; }
+  Memory<int> *mutable_extra_memory() { return extra_shape_; }
+  bool has_extra_memory() const { return extra_shape_ != NULL; }
+  void create_extra_memory(int len) {
+    if (extra_shape_ != NULL)
+      delete extra_shape_;
+    extra_shape_ = new Memory<int>(len, 1, 1, 1);
+  }
+  void create_extra_memory(int len, int *data) {
+    if (extra_shape_ != NULL)
+      delete extra_shape_;
+    extra_shape_ = new Memory<int>(len, 1, 1, 1, data);
+  }
+
+private:
+  MessageID id_;
+  Memory<Dtype> *mem_;  // contains data.
+  Memory<int> *extra_shape_; // contains extra shape data.
+};
+
+struct BatchPair {
+  BatchPair(int bi, int bs) : batch_index(bi), batch_size(bs) {}
+  int batch_index;
+  int batch_size;
+};
+
+template<typename Dtype, typename HostDtype>
+class BasicContext{
+public:
+
+  BasicContext(void) {
+  }
+  ~BasicContext(void) {
+  };
+  virtual Message<Dtype> *prepare_message(MessageHdr<Dtype> hdr) { return NULL; };
+  virtual Message<Dtype> *prepare_message(MessageID id) { return NULL; };
+  virtual void prepare_messages(std::vector <Message<Dtype> *> &msgs) { };
+  virtual void handle_messages(std::vector <Message<Dtype> *> &msg, std::vector <Message<Dtype> *> &output_messages) {};
+  // The following two implementation is for LSTM work load on VCA card.
+  virtual int get_prefer_batch_size(int total_bs, int client_num) {
+    int bs = ((total_bs + client_num - 1) / client_num);
+    // Make bs 4 aligned. 
+    if (bs % 4 != 0 && (total_bs >= client_num * 8)) {
+      if (total_bs - (bs & ~3) * client_num < 4)
+        bs = bs & ~3;
+      else
+        bs = (bs + 3) & ~3;
+    }
+    // Set the minimum batch size to half of the batch size.
+    if (bs < 4)
+      bs = 4;
+    return bs;
+  }
+  virtual int get_actual_batch_size(int prefer_bs, int total_bs) {
+    if (prefer_bs >= total_bs)
+      prefer_bs = total_bs;
+    else if (total_bs - prefer_bs < 4)
+      prefer_bs = total_bs;
+    return prefer_bs;
+  }
+  void set_batch_size(int bs) {
+    batch_size_ = bs;
+  }
+
+  std::vector <int> BatchSent;
+  int batch_size_;
+};
+
+template<typename Dtype, typename HostDtype>
+class Node {
+public:
+  Node(NodeType type,
+       BasicContext<Dtype, HostDtype> * ctx) {
+    type_ = type;
+    ctx_ = ctx;
+    weights_bytes_ = 0;
+    sent_bytes_total_ = 0;
+    recved_bytes_total_ = 0;
+  }
+
+  Node(NodeType type,
+       BasicContext<Dtype, HostDtype> * ctx,
+       int clients_num) {
+    type_ = type;
+    ctx_ = ctx;
+    clients_num_ = clients_num;
+    sent_bytes_total_ = 0;
+    recved_bytes_total_ = 0;
+    weights_bytes_ = 0;
+  }
+
+  void set_host_addr(const char * host_addr, int port) {
+    if (inet_pton(AF_INET, host_addr, &host_addr_.sin_addr) < 0) {
+      printf("invalid host addr %s \n", host_addr);
+      exit(-1);
+    }
+    host_addr_.sin_port = htons(port);
+    host_addr_.sin_family = AF_INET;
+  }
+
+  void Forward(const std::vector<Message<Dtype> *> input_messages, std::vector<Message<Dtype> *> output_messages) {
+    unsigned int total_bs = input_messages[0]->memory()->batch_size();
+    int bs = ctx_->get_prefer_batch_size(total_bs, sockets_.size());
+    unsigned int batch_index = 0;
+    std::vector<int> sockets = sockets_;
+    unsigned int batch_processed = 0;
+    std::vector <struct epoll_event> events;
+    events.resize(clients_num_);
+    ctx_->BatchSent.clear();
+    while(batch_processed < total_bs) {
+      if (sockets.size() > 0 && batch_index < total_bs) {
+        int actual_bs = ctx_->get_actual_batch_size(bs, total_bs - batch_index);
+        int socket = sockets.back();
+        sockets.pop_back();
+        SendSubMessages(input_messages, batch_index, actual_bs, socket);
+        ctx_->BatchSent.push_back(actual_bs);
+        BatchPair bp(batch_index, actual_bs);
+        batch_index += actual_bs;
+        sub_msgs_.insert(std::make_pair(socket, bp));
+      } else {
+        // epoll all sockets
+        int event_count = epoll_wait(epfds_, &events[0], clients_num_ * output_messages.size(), 200);
+        for (int i = 0; i < event_count; i++) {
+          if (events[i].data.fd < 0)
+            continue;
+          if (events[i].events & EPOLLIN) {
+            int socket = events[i].data.fd;
+            auto it = sub_msgs_.find(socket);
+            assert(it != sub_msgs_.end());
+            BatchPair bp = it->second;
+            ReceiveSubMessages(output_messages, bp.batch_index, bp.batch_size, socket);
+            batch_processed += bp.batch_size;
+            sub_msgs_.erase(it);
+            sockets.insert(sockets.begin(), socket);
+          }
+        }
+      }
+    }
+  }
+
+  int Run() {
+    if (type_ == NodeTypeHost) {
+      printf("Initializing host node, prepare to get %d clients \n", clients_num_);
+      // wait here to initialize all clients.
+      epfds_ = epoll_create(256);
+      int listen_fd = socket(AF_INET, SOCK_STREAM, 0);
+      int reuse_addr = 1;
+      setsockopt(listen_fd,
+                 SOL_SOCKET,
+                 SO_REUSEADDR,
+                 (const char*)&reuse_addr,
+                 sizeof(int));
+      if (bind(listen_fd, (sockaddr *)&host_addr_, sizeof(host_addr_)) < 0) {
+        perror("failed to bind the address.\n");
+        exit(-1);
+      }
+      if (listen(listen_fd, 64) < 0) {
+        perror("failed to listen the server address and port.\n");
+        exit(-1);
+      }
+      Message<Dtype> *msg = ctx_->prepare_message(InitWeight);
+      while(sockets_.size() < clients_num_) {
+        // accept all clients and register to epfd
+        struct sockaddr_in client_addr;
+        socklen_t client_len;
+        char client_name[128];
+        inet_ntop(AF_INET, (void*)&(host_addr_.sin_addr), client_name, 127);
+        std::cout << "Listening :" << client_name << ". Port: "
+                  << ntohs(host_addr_.sin_port) << std::endl;
+        int conn_fd = accept(listen_fd, (sockaddr *)&client_addr, &client_len);
+        inet_ntop(AF_INET, (void*)&(client_addr.sin_addr), client_name, 127);
+        std::cout << "Got a client from :" << client_name << ". Port: "
+                  << ntohs(client_addr.sin_port) << std::endl;
+        if (conn_fd < 0) {
+          perror("accept client failed.");
+          exit(-1);
+        }
+        struct epoll_event event;
+        event.data.fd = conn_fd;
+        event.events = EPOLLIN | EPOLLET;
+        epoll_ctl(epfds_, EPOLL_CTL_ADD, conn_fd, &event);
+        sockets_.push_back(conn_fd);
+        SendMessage(msg, conn_fd);
+        weights_bytes_ += msg->memory()->count(0) * sizeof(Dtype);
+      }
+      close(listen_fd);
+    } else if (type_ == NodeTypeClient) {
+      // wait here to get weights or data from host.
+      int conn_fd = socket(AF_INET, SOCK_STREAM, 0);
+      if (conn_fd < 0) {
+        perror("failed to create socket");
+        exit(-1);
+      }
+
+      while (1) {
+        if (connect(conn_fd, (struct sockaddr *)&host_addr_,
+            sizeof(host_addr_)) < 0) {
+          if (errno != ECONNREFUSED) {
+            printf("err = %d ECO %d \n", errno, ECONNREFUSED);
+            perror("failed to connect to host.");
+            exit(-2);
+          } else {
+            printf("Host is not ready, retry after 1 second.\n");
+            sleep(1);
+          }
+        } else {
+          printf("Connected to host.\n");
+          break;
+        }
+      }
+      try {
+        while(1) {
+          std::vector <Message<Dtype> *> msgs;
+          ctx_->prepare_messages(msgs);
+          if (ReceiveMessages(msgs, conn_fd) < 0)
+            break;
+          std::vector <Message<Dtype> *> output_msgs;
+          ctx_->handle_messages(msgs, output_msgs);
+          SendMessages(output_msgs, conn_fd);
+        }
+        // graceful shutdown.
+        close(conn_fd);
+      } catch (int err) {
+        close(conn_fd);
+      }
+    }
+    return 0;
+  }
+
+  ~Node() {
+    if (sockets_.size() != 0) {
+      MessageHdr<Dtype> exit_msg(ExitMessage);
+      std::cout << "Sending exit message to clients. " << std::endl;
+      for (unsigned int i = 0; i < sockets_.size(); i++) {
+        SendMessageHdr(exit_msg, sockets_[i]);
+        close(sockets_[i]);
+      }
+      sockets_.clear();
+      close(epfds_);
+    }
+    printf("Received %.1f MB, sent %.1f MB", recved_bytes_total_/1.e6, sent_bytes_total_/1.e6);
+    if (type_ == NodeTypeHost) {
+      printf("(including weights %.1f MB)", weights_bytes_/1.e6);
+    }
+    printf("\n");
+  }
+
+private:
+
+  size_t sent_bytes_total_;
+  size_t recved_bytes_total_;
+  size_t weights_bytes_;
+
+  ssize_t Send(int sockfd, const void *buf, size_t len, int flags) {
+    size_t total_bytes_sent = 0;
+    sent_bytes_total_ += len;
+    while (total_bytes_sent < len) {
+      ssize_t bytes_sent = send(sockfd, (const uint8_t*)buf + total_bytes_sent, len - total_bytes_sent, flags * 0);
+      if (bytes_sent < 0) {
+        perror("fatal error when sending data.\n");
+        throw (errno);
+      }
+      total_bytes_sent += bytes_sent;
+    }
+    return total_bytes_sent;
+  }
+
+  ssize_t Recv(int sockfd, void *buf, size_t len, int flags) {
+    size_t total_bytes_recved = 0;
+    recved_bytes_total_ += len;
+
+    while (total_bytes_recved < len) {
+      ssize_t bytes_recved = recv(sockfd, (uint8_t*)buf + total_bytes_recved, len - total_bytes_recved, flags);
+      if (bytes_recved < 0) {
+        perror("fatal error when receiving data.\n");
+        throw (errno);
+      }
+      total_bytes_recved += bytes_recved;
+    }
+    return total_bytes_recved;
+  }
+
+  void SendMessages(const std::vector <Message<Dtype> *> &messages,
+                   int socket) {
+    for (unsigned int i = 0; i < messages.size(); i++)
+      SendMessage(messages[i], socket);
+  }
+
+  void SendMessage(const Message<Dtype> *message,
+                   int socket) {
+    MessageHdr<Dtype> hdr(message->id());
+    hdr.shape[0] = message->memory()->shape()[0];
+    hdr.shape[1] = message->memory()->shape()[1];
+    hdr.shape[2] = message->memory()->shape()[2];
+    hdr.shape[3] = message->memory()->shape()[3];
+    hdr.extra_shape_len = message->has_extra_memory() ?
+                          message->extra_memory()->count(0) : 0;
+    int sent_bytes = Send(socket, &hdr, sizeof(hdr), MSG_MORE);
+    assert(sent_bytes == sizeof(hdr));
+    if (hdr.extra_shape_len > 0) {
+      sent_bytes = Send(socket, message->extra_memory()->data(), hdr.extra_shape_len * sizeof(int), MSG_MORE);
+      assert(sent_bytes == (int)(hdr.extra_shape_len * sizeof(int)));
+    }
+    sent_bytes = Send(socket, message->memory()->data(), hdr.len() * sizeof(Dtype), MSG_DONTWAIT);
+    assert(sent_bytes == (int)(hdr.len() * sizeof(Dtype)));
+  }
+
+  void SendMessageHdr(MessageHdr<Dtype> hdr, int socket) {
+    int sent_bytes = Send(socket, &hdr, sizeof(hdr), MSG_DONTWAIT);
+    assert(sent_bytes == sizeof(hdr));
+  }
+
+  void SendSubMessages(const std::vector <Message<Dtype> *> &messages,
+                      int batch_index,
+                      int bs,
+                      int socket) {
+    for (unsigned int i = 0; i < messages.size(); i++)
+      SendSubMessage(messages[i], batch_index, bs, socket);
+  }
+
+  void SendSubMessage(const Message<Dtype> *message,
+                      int batch_index,
+                      int bs,
+                      int socket) {
+    MessageHdr<Dtype> hdr(message->id());
+    hdr.id = message->id();
+    hdr.shape[0] = bs;
+    hdr.shape[1] = message->memory()->shape()[1];
+    hdr.shape[2] = message->memory()->shape()[2];
+    hdr.shape[3] = message->memory()->shape()[3];
+    hdr.extra_shape_len = message->has_extra_memory() ?
+                          (message->extra_memory()->count(1) * bs) : 0;
+    int sent_bytes = Send(socket, &hdr, sizeof(hdr), MSG_MORE);
+    assert(sent_bytes == sizeof(hdr));
+    if (hdr.extra_shape_len > 0) {
+      sent_bytes = Send(socket, &message->extra_memory()->const_at(batch_index, 0, 0, 0),
+           hdr.extra_shape_len * sizeof(int), MSG_MORE);
+      assert(sent_bytes == (int)(hdr.extra_shape_len * sizeof(int)));
+    }
+    sent_bytes = Send(socket, &message->memory()->const_at(batch_index, 0, 0, 0),
+         hdr.len() * sizeof(Dtype), MSG_DONTWAIT);
+    assert(sent_bytes == (int)(hdr.len() * sizeof(Dtype)));
+  }
+
+  // Receive sub messages from client side.
+  // The host side should prepare appropriate input messages.
+  void ReceiveSubMessages(std::vector <Message<Dtype> *> &messages,
+                         int batch_index,
+                         int bs,
+                         int socket) {
+    for (unsigned int i = 0; i < messages.size(); i++) {
+      MessageHdr<Dtype> hdr;
+      int recv_bytes = Recv(socket, &hdr, sizeof(hdr), MSG_WAITALL);
+      assert(recv_bytes == (int)sizeof(hdr));
+      assert(hdr.data_type == GetDataType<Dtype>());
+      assert(hdr.len() == bs * messages[i]->memory()->count(1));
+      if (hdr.extra_shape_len != 0) {
+        assert(messages[i]->has_extra_memory());
+        int *shape_data = &messages[i]->mutable_extra_memory()->at(batch_index, 0, 0, 0);
+        recv_bytes = Recv(socket, shape_data, hdr.extra_shape_len * sizeof(int), MSG_WAITALL);
+        assert(recv_bytes == (int)(hdr.extra_shape_len * sizeof(int)));
+      }
+      Dtype *ptr = &messages[i]->mutable_memory()->at(batch_index, 0, 0, 0);
+      recv_bytes = Recv(socket, ptr, hdr.len() * sizeof(Dtype), MSG_WAITALL);
+      assert(recv_bytes == (int)(hdr.len() * sizeof(Dtype)));
+    }
+  }
+
+  // Used by client side to receive messages from host side.
+  int ReceiveMessages(std::vector <Message<Dtype> *> &messages,
+                      int socket) {
+    for (unsigned int i = 0; i < messages.size(); i++) {
+      MessageHdr<Dtype> hdr;
+      int recv_bytes = Recv(socket, &hdr, sizeof(MessageHdr<Dtype>), MSG_WAITALL);
+      assert(recv_bytes == sizeof(MessageHdr<Dtype>));
+      assert(hdr.data_type == GetDataType<Dtype>());
+      if (hdr.id == ExitMessage) {
+        if (i != 0)
+          printf("Warning: got exit message with some unhandled data.\n");
+        printf("got exit message from host, exiting. \n");
+        return -1;
+      }
+      assert(hdr.id == messages[i]->id());
+      if (hdr.extra_shape_len != 0) {
+        if (!messages[i]->has_extra_memory())
+          messages[i]->create_extra_memory(hdr.extra_shape_len);
+        else
+          messages[i]->mutable_extra_memory()->reshape(hdr.extra_shape_len, 1, 1, 1);
+        int *shape_data = messages[i]->mutable_extra_memory()->mutable_data();
+        recv_bytes = Recv(socket, shape_data, hdr.extra_shape_len * sizeof(int), MSG_WAITALL);
+        assert(recv_bytes == (int)(hdr.extra_shape_len * sizeof(int)));
+      }
+      messages[i]->mutable_memory()->reshape(hdr.shape[0],
+                                             hdr.shape[1],
+                                             hdr.shape[2],
+                                             hdr.shape[3]);
+      recv_bytes = Recv(socket,
+                        messages[i]->mutable_memory()->mutable_data(),
+                        hdr.len() * sizeof(Dtype),
+                        MSG_WAITALL);
+      assert(recv_bytes == (int)(hdr.len() * sizeof(Dtype)));
+    }
+    return 0;
+  }
+
+  NodeType type_;
+  std::vector<int> sockets_;
+  std::map<int, BatchPair> sub_msgs_;
+  int epfds_;
+  BasicContext<Dtype, HostDtype> *ctx_;
+  struct sockaddr_in host_addr_;
+  unsigned int clients_num_;
+};
+} // namespace simple_mqueue
+#endif


### PR DESCRIPTION
Hi @gongzg 
This patch add host/client service for video analysis at exampels/video_analysis_host_client

The host code modified from video_analysis.cpp, example command to show the service as below.
```
./build/examples/video_analysis_host_client/video_analysis_host model models/VGGNet/VOC0712/SSD_300x300/deploy.prototxt weights models/VGGNet/VOC0712/SSD_300x300/VGG_VOC0712_SSD_300x300_iter_120000.caffemodel video examples/videos/ILSVRC2015_train_00755001.mp4 v true

./build/examples/video_analysis_host_client/video_analysis_client.bin -model models/VGGNet/VOC0712/SSD_300x300/deploy.prototxt -weights models/VGGNet/VOC0712/SSD_300x300/VGG_VOC0712_SSD_300x300_iter_120000.caffemodel -float_width 32
```
