### PR TITLE
Add the proporties of -pie for executables to pass hardening-check.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -10,6 +10,7 @@ foreach(source_file ${examples_srcs})
 
   add_executable(${name} ${source_file})
   target_link_libraries(${name} ${Caffe_LINK})
+  set_target_properties(${name} PROPERTIES LINK_FLAGS "-pie")
   caffe_default_properties(${name})
 
   if(MSVC AND COPY_PREREQUISITES)

--- a/src/caffe/test/CMakeLists.txt
+++ b/src/caffe/test/CMakeLists.txt
@@ -32,6 +32,7 @@ endif()
 # ---[ Adding test target
 add_executable(${the_target} EXCLUDE_FROM_ALL ${test_srcs})
 target_link_libraries(${the_target} gtest ${Caffe_LINK})
+set_target_properties(${name} PROPERTIES LINK_FLAGS "-pie")
 caffe_default_properties(${the_target})
 caffe_set_runtime_directory(${the_target} "${PROJECT_BINARY_DIR}/test")
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -13,6 +13,7 @@ foreach(source ${srcs})
   # target
   add_executable(${name} ${source})
   target_link_libraries(${name} ${Caffe_LINK})
+  set_target_properties(${name} PROPERTIES LINK_FLAGS "-pie")
   caffe_default_properties(${name})
 
   if(MSVC AND COPY_PREREQUISITES)


### PR DESCRIPTION
Hi @gongzg ,

This patch add LDFLAGS of "-pie" for executable to comply to  Compile code defenses enable rule.