### PR TITLE
Remove unnecessary OpenCV headers

### DIFF
--- a/src/caffe/layers/malis_loss_layer.cpp
+++ b/src/caffe/layers/malis_loss_layer.cpp
@@ -1,6 +1,4 @@
 #include <boost/pending/disjoint_sets.hpp>
-#include <opencv2/highgui/highgui.hpp>
-#include <opencv2/imgproc/imgproc.hpp>
 
 #include <algorithm>
 #include <cfloat>


### PR DESCRIPTION
Including these headers causes a build failure when building with USE_OPENCV disabled.
This file doesn't use any OpenCV calls that I can tell, so I don't think there is any reason to include these headers.