### PR TITLE
Fix a potential compiling error in dwconv kernel.

### DIFF
--- a/src/caffe/greentea/cl_kernels.cpp
+++ b/src/caffe/greentea/cl_kernels.cpp
@@ -952,6 +952,9 @@ static std::vector<std::vector<std::string>> cl_kernels{
 "{",    // NOLINT
 "int_tp item = sub_id + reg * SIMD_SIZE;",    // NOLINT
 "local_kernel_data[reg] = kernel_dataPtrFloat[item];",    // NOLINT
+"if (channel_id > 0xfffffffeul) {",    // NOLINT
+"convolved_image[0] = local_kernel_data[reg];",    // NOLINT
+"}",    // NOLINT
 "}",    // NOLINT
 ");",    // NOLINT
 "",    // NOLINT

--- a/src/caffe/greentea/cl_kernels/conv_layer_spatial.cl
+++ b/src/caffe/greentea/cl_kernels/conv_layer_spatial.cl
@@ -178,6 +178,9 @@ __kernel void DWCONV(
       {
         int_tp item = sub_id + reg * SIMD_SIZE;
         local_kernel_data[reg] = kernel_dataPtrFloat[item];
+        if (channel_id > 0xfffffffeul) {
+          convolved_image[0] = local_kernel_data[reg];
+        }
       }
   );
   


### PR DESCRIPTION
Hi @gongzg 
This patch fix the compiler error optimized when block size is (1,1) in dwconv ocl kernel.