### PR TITLE
Fixed an bug on pycaffe binding lacking SetDevices definition for CPU_ONLY mode

### DIFF
--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -90,14 +90,14 @@ void set_mode_cpu() { Caffe::set_mode(Caffe::CPU); }
 void set_mode_gpu() { Caffe::set_mode(Caffe::GPU); }
 void select_device(int id, bool listId) { Caffe::SelectDevice(id, listId); }
 void set_devices(bp::tuple args) {
+#ifndef CPU_ONLY
   vector<int> devices(bp::len(args));
   for (int i = 0; i < bp::len(args); ++i) {
     devices[i] = bp::extract<int>(args[i]);
   }
   Caffe::SetDevices(devices);
+#endif
 }
-
-
 void InitLog(int level) {
   FLAGS_logtostderr = 1;
   FLAGS_minloglevel = level;


### PR DESCRIPTION
Hi @gongzg 
This patch fixed the python binding un-definition of SetDevices bug.